### PR TITLE
Start symmetric decompression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle <22795598+gdalle@users.noreply.github.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,14 +26,24 @@ LargestFirst
 ### Decompression
 
 ```@docs
-decompress_columns!
-decompress_columns
-decompress_rows!
-decompress_rows
 color_groups
+decompress_columns
+decompress_columns!
+decompress_rows
+decompress_rows!
+decompress_symmetric
+decompress_symmetric!
 ```
 
 ## Private
+
+### Matrices
+
+```@docs
+matrix_versions
+respectful_similar
+same_sparsity_pattern
+```
 
 ### Graphs
 

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -8,7 +8,16 @@ module SparseMatrixColorings
 using ADTypes: ADTypes, AbstractColoringAlgorithm
 using Compat: @compat
 using DocStringExtensions: README
-using LinearAlgebra: Diagonal, Transpose, checksquare, parent, transpose
+using LinearAlgebra:
+    Adjoint,
+    Diagonal,
+    Symmetric,
+    Transpose,
+    adjoint,
+    checksquare,
+    issymmetric,
+    parent,
+    transpose
 using Random: AbstractRNG, default_rng, randperm
 using SparseArrays:
     SparseArrays,
@@ -25,15 +34,18 @@ using SparseArrays:
 include("graph.jl")
 include("order.jl")
 include("coloring.jl")
+include("groups.jl")
 include("adtypes.jl")
-include("check.jl")
+include("matrices.jl")
 include("decompression.jl")
+include("check.jl")
 
 @compat public GreedyColoringAlgorithm
 @compat public NaturalOrder, RandomOrder, LargestFirst
-@compat public decompress_columns!, decompress_columns
-@compat public decompress_rows!, decompress_rows
 @compat public color_groups
+@compat public decompress_columns, decompress_columns!
+@compat public decompress_rows, decompress_rows!
+@compat public decompress_symmetric, decompress_symmetric!
 
 export GreedyColoringAlgorithm
 

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -20,6 +20,9 @@ function decompress_columns!(
     C::AbstractMatrix{R},
     colors::AbstractVector{<:Integer},
 ) where {R<:Real}
+    if !same_sparsity_pattern(A, S)
+        throw(DimensionMismatch("`A` and `S` must have the same sparsity pattern."))
+    end
     A .= zero(R)
     for j in axes(A, 2)
         k = colors[j]
@@ -93,6 +96,9 @@ function decompress_rows!(
     C::AbstractMatrix{R},
     colors::AbstractVector{<:Integer},
 ) where {R<:Real}
+    if !same_sparsity_pattern(A, S)
+        throw(DimensionMismatch("`A` and `S` must have the same sparsity pattern."))
+    end
     A .= zero(R)
     for i in axes(A, 1)
         k = colors[i]

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -1,0 +1,16 @@
+"""
+    color_groups(colors)
+
+Return `groups::Vector{Vector{Int}}` such that `i ∈ groups[c]` iff `colors[i] == c`.
+
+Assumes the colors are contiguously numbered from `1` to some `cmax`.
+"""
+function color_groups(colors::AbstractVector{<:Integer})
+    cmin, cmax = extrema(colors)
+    @assert cmin == 1
+    groups = [Int[] for c in 1:cmax]
+    for (k, c) in enumerate(colors)
+        push!(groups[c], k)
+    end
+    return groups
+end

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -1,0 +1,83 @@
+const TransposeOrAdjoint{T,M} = Union{Transpose{T,M},Adjoint{T,M}}
+
+"""
+    matrix_versions(A::AbstractMatrix)
+
+Return various versions of the same matrix:
+
+- dense and sparse
+- transpose and adjoint
+
+Used for internal testing.
+"""
+function matrix_versions(A)
+    A_dense = Matrix(A)
+    A_sparse = SparseMatrixCSC(A)
+    versions = [
+        A_dense,
+        transpose(Matrix(transpose(A_dense))),
+        adjoint(Matrix(adjoint(A_dense))),
+        A_sparse,
+        transpose(SparseMatrixCSC(transpose(A_sparse))),
+        adjoint(SparseMatrixCSC(adjoint(A_sparse))),
+    ]
+    if issymmetric(A)
+        append!(versions, [Symmetric(A_dense), Symmetric(A_sparse)])
+    end
+    return versions
+end
+
+"""
+    respectful_similar(A::AbstractMatrix)
+    respectful_similar(A::AbstractMatrix, ::Type{T})
+
+Like `Base.similar` but returns a transpose or adjoint when `A` is a transpose or adjoint.
+"""
+respectful_similar(A::AbstractMatrix) = respectful_similar(A, eltype(A))
+
+respectful_similar(A::AbstractMatrix, ::Type{T}) where {T} = similar(A, T)
+
+function respectful_similar(A::Transpose, ::Type{T}) where {T}
+    return transpose(similar(parent(A), T))
+end
+
+function respectful_similar(A::Adjoint, ::Type{T}) where {T}
+    return adjoint(similar(parent(A), T))
+end
+
+"""
+    same_sparsity_pattern(A::AbstractMatrix, B::AbstractMatrix)
+
+Perform a partial equality check on the sparsity patterns of `A` and `B`:
+
+- if the return is `true`, they might have the same sparsity pattern but we're not sure
+- if the return is `false`, they definitely don't have the same sparsity pattern
+"""
+function same_sparsity_pattern(A::AbstractMatrix, B::AbstractMatrix)
+    return true
+end
+
+function same_sparsity_pattern(A::SparseMatrixCSC, B::SparseMatrixCSC)
+    if size(A) != size(B)
+        return false
+    elseif nnz(A) != nnz(B)
+        return false
+    else
+        for j in axes(A, 2)
+            rA = nzrange(A, j)
+            rB = nzrange(B, j)
+            if rA != rB
+                return false
+            end
+            # TODO: check rowvals?
+        end
+        return true
+    end
+end
+
+function same_sparsity_pattern(
+    A::TransposeOrAdjoint{<:Any,<:SparseMatrixCSC},
+    B::TransposeOrAdjoint{<:Any,<:SparseMatrixCSC},
+)
+    return same_sparsity_pattern(parent(A), parent(B))
+end

--- a/test/check.jl
+++ b/test/check.jl
@@ -29,7 +29,7 @@ end
 end
 
 @testset "Symmetrically orthogonal" begin
-    # fig 4.1 of "What color is your Jacobian?"
+    # Fig 4.1 of "What color is your Jacobian?"
     A = [
         1 1 0 0 0 0
         1 1 1 0 1 1

--- a/test/coloring_correctness.jl
+++ b/test/coloring_correctness.jl
@@ -5,7 +5,8 @@ using SparseMatrixColorings:
     GreedyColoringAlgorithm,
     check_structurally_orthogonal_columns,
     check_structurally_orthogonal_rows,
-    check_symmetrically_orthogonal
+    check_symmetrically_orthogonal,
+    matrix_versions
 using StableRNGs
 using Test
 
@@ -16,41 +17,36 @@ algo = GreedyColoringAlgorithm()
 @test startswith(string(algo), "GreedyColoringAlgorithm(")
 
 @testset "Column coloring" begin
-    @testset "$(typeof(A)) - $(size(A))" for A in (
-        sprand(rng, Bool, 100, 200, 0.05),
-        sprand(rng, Bool, 200, 100, 0.05),
-        Matrix(sprand(rng, Bool, 100, 200, 0.05)),
-        Matrix(sprand(rng, Bool, 200, 100, 0.05)),
+    @testset "A::$(typeof(A)) of size $(size(A))" for A in vcat(
+        matrix_versions(sprand(rng, Bool, 100, 200, 0.05)),
+        matrix_versions(sprand(rng, Bool, 200, 100, 0.05)),
     )
         column_colors = column_coloring(A, algo)
         @test check_structurally_orthogonal_columns(A, column_colors)
         @test minimum(column_colors) == 1
         @test maximum(column_colors) < size(A, 2) ÷ 2
     end
-end
+end;
 
 @testset "Row coloring" begin
-    @testset "$(typeof(A)) - $(size(A))" for A in (
-        sprand(rng, Bool, 100, 200, 0.05),
-        sprand(rng, Bool, 200, 100, 0.05),
-        Matrix(sprand(rng, Bool, 100, 200, 0.05)),
-        Matrix(sprand(rng, Bool, 200, 100, 0.05)),
+    @testset "A::$(typeof(A)) of size $(size(A))" for A in vcat(
+        matrix_versions(sprand(rng, Bool, 100, 200, 0.05)),
+        matrix_versions(sprand(rng, Bool, 200, 100, 0.05)),
     )
         row_colors = row_coloring(A, algo)
         @test check_structurally_orthogonal_rows(A, row_colors)
         @test minimum(row_colors) == 1
         @test maximum(row_colors) < size(A, 1) ÷ 2
     end
-end
+end;
 
 @testset "Symmetric coloring" begin
-    @testset "$(typeof(A)) - $(size(A))" for A in (
-        sparse(Symmetric(sprand(rng, Bool, 100, 100, 0.05))),
-        Symmetric(Matrix(sprand(rng, Bool, 100, 100, 0.05))),
+    @testset "A::$(typeof(A)) of size $(size(A))" for A in matrix_versions(
+        Symmetric(sprand(rng, Bool, 100, 100, 0.05))
     )
         symmetric_colors = symmetric_coloring(A, algo)
         @test check_symmetrically_orthogonal(A, symmetric_colors)
         @test minimum(symmetric_colors) == 1
         @test maximum(symmetric_colors) < size(A, 2) ÷ 2
     end
-end
+end;

--- a/test/decompression_correctness.jl
+++ b/test/decompression_correctness.jl
@@ -1,3 +1,4 @@
+using Base.Iterators: product
 using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using Compat
 using LinearAlgebra
@@ -11,6 +12,7 @@ using SparseMatrixColorings:
     decompress_rows!,
     decompress_symmetric,
     decompress_symmetric!,
+    matrix_versions,
     same_sparsity_pattern
 using StableRNGs
 using Test
@@ -18,39 +20,6 @@ using Test
 rng = StableRNG(63)
 
 algo = GreedyColoringAlgorithm()
-
-@testset "Sparsity pattern comparison" begin
-    A = [
-        1 1
-        0 1
-        0 0
-    ]
-    B1 = [
-        1 1
-        0 1
-        1 0
-    ]
-    B2 = [
-        1 1
-        0 0
-        0 1
-    ]
-    C = [
-        1 1 0
-        0 1 0
-        0 0 0
-    ]
-
-    @test same_sparsity_pattern(sparse(A), sparse(A))
-    @test !same_sparsity_pattern(sparse(A), sparse(B1))
-    @test_broken !same_sparsity_pattern(sparse(A), sparse(B2))
-    @test !same_sparsity_pattern(sparse(A), sparse(C))
-
-    @test same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(A)))
-    @test !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(B1)))
-    @test_broken !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(B2)))
-    @test !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(C)))
-end;
 
 @testset "Column decompression" begin
     @testset "Small" begin
@@ -70,18 +39,13 @@ end;
             5 0
         ]
         colors = [1, 1, 2]
-        @testset "$(typeof(A)) - $(typeof(S))" for (A, S) in [
-            (A0, S0),  #
-            (sparse(A0), sparse(S0)),
-        ]
+        @testset "A::$(typeof(A)) - S::$(typeof(S))" for (A, S) in product(
+            matrix_versions(A0), matrix_versions(S0)
+        )
             @test decompress_columns(S, C, colors) == A
-            if A isa SparseMatrixCSC
-                @test_throws DimensionMismatch decompress_columns!(
-                    similar(A), false .* S, C, colors
-                )
-            end
         end
     end
+
     @testset "Medium" begin
         m, n = 18, 20
         A0 = sprand(rng, Bool, m, n, 0.2)
@@ -92,14 +56,13 @@ end;
             dropdims(sum(A0[:, group]; dims=2); dims=2)
         end
         @test size(C) == (size(A0, 1), length(groups))
-        @testset "$(typeof(A)) - $(typeof(S))" for (A, S) in [
-            (A0, S0),  #
-            (Matrix(A0), Matrix(S0)),
-        ]
+        @testset "A::$(typeof(A)) - S::$(typeof(S))" for (A, S) in product(
+            matrix_versions(A0), matrix_versions(S0)
+        )
             @test decompress_columns(S, C, colors) == A
         end
     end
-end
+end;
 
 @testset "Row decompression" begin
     @testset "Small" begin
@@ -118,38 +81,30 @@ end
             4 5 0
         ]
         colors = [1, 1, 2]
-        @testset "$(typeof(A)) - $(typeof(S))" for (A, S) in [
-            (A0, S0), #
-            (transpose(sparse(transpose(A0))), transpose(sparse(transpose(S0)))),
-        ]
+        @testset "A::$(typeof(A)) - S::$(typeof(S))" for (A, S) in product(
+            matrix_versions(A0), matrix_versions(S0)
+        )
             @test decompress_rows(S, C, colors) == A
-            if A isa Transpose{<:Any,<:SparseMatrixCSC}
-                @test_throws DimensionMismatch decompress_rows!(
-                    transpose(similar(parent(A))), transpose(false .* parent(S)), C, colors
-                )
-            end
         end
     end
+
     @testset "Medium" begin
         m, n = 18, 20
         A0 = sprand(rng, Bool, m, n, 0.2)
         S0 = map(!iszero, A0)
-        A0t = transpose(A0)
-        S0t = transpose(S0)
-        colors = row_coloring(A0t, algo)
+        colors = row_coloring(A0, algo)
         groups = color_groups(colors)
-        Ct = stack(groups; dims=1) do group
-            dropdims(sum(A0t[group, :]; dims=1); dims=1)
+        C = stack(groups; dims=1) do group
+            dropdims(sum(A0[group, :]; dims=1); dims=1)
         end
-        @test size(Ct) == (length(groups), size(A0t, 2))
-        @testset "$(typeof(At)) - $(typeof(St))" for (At, St) in [
-            (A0t, S0t),  #
-            (Matrix(A0t), Matrix(S0t)),
-        ]
-            @test decompress_rows(St, Ct, colors) == At
+        @test size(C) == (length(groups), size(A0, 2))
+        @testset "A::$(typeof(A)) - S::$(typeof(S))" for (A, S) in product(
+            matrix_versions(A0), matrix_versions(S0)
+        )
+            @test decompress_rows(S, C, colors) == A
         end
     end
-end
+end;
 
 @testset "Symmetric decompression" begin
     @testset "Small" begin
@@ -172,9 +127,13 @@ end
             1,  # green
         ]
         groups = color_groups(colors)
-        C0 = stack(groups; dims=2) do group
+        C = stack(groups; dims=2) do group
             dropdims(sum(A0[:, group]; dims=2); dims=2)
         end
-        @test decompress_symmetric(S0, C0, colors) == A0
+        @testset "A::$(typeof(A)) - S::$(typeof(S))" for (A, S) in product(
+            matrix_versions(A0), matrix_versions(S0)
+        )
+            @test decompress_symmetric(S, C, colors) == A
+        end
     end
-end
+end;

--- a/test/decompression_correctness.jl
+++ b/test/decompression_correctness.jl
@@ -9,6 +9,8 @@ using SparseMatrixColorings:
     decompress_columns!,
     decompress_rows,
     decompress_rows!,
+    decompress_symmetric,
+    decompress_symmetric!,
     same_sparsity_pattern
 using StableRNGs
 using Test
@@ -146,5 +148,33 @@ end
         ]
             @test decompress_rows(St, Ct, colors) == At
         end
+    end
+end
+
+@testset "Symmetric decompression" begin
+    @testset "Small" begin
+        # Fig 4.1 from "What color is your Jacobian?"
+        A0 = [
+            1 2 0 0 0 0
+            2 3 4 0 5 6
+            0 4 7 8 0 0
+            0 0 8 9 0 10
+            0 5 0 0 11 0
+            0 6 0 10 0 12
+        ]
+        S0 = (!iszero).(A0)
+        colors = [
+            1,  # green
+            2,  # red
+            1,  # green
+            3,  # blue
+            1,  # green
+            1,  # green
+        ]
+        groups = color_groups(colors)
+        C0 = stack(groups; dims=2) do group
+            dropdims(sum(A0[:, group]; dims=2); dims=2)
+        end
+        @test decompress_symmetric(S0, C0, colors) == A0
     end
 end

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -1,0 +1,65 @@
+using SparseArrays
+using SparseMatrixColorings: matrix_versions, respectful_similar, same_sparsity_pattern
+using StableRNGs
+using Test
+
+rng = StableRNG(63)
+
+@testset "Matrix versions" begin
+    A0_dense = rand(3, 4)
+    A0_sparse = sprand(rng, 10, 20, 0.3)
+    @test all(==(A0_dense), matrix_versions(A0_dense))
+    @test all(==(A0_sparse), matrix_versions(A0_sparse))
+end
+
+same_view(::AbstractMatrix, ::AbstractMatrix) = false
+same_view(::Matrix, ::Matrix) = true
+same_view(::SparseMatrixCSC, ::SparseMatrixCSC) = true
+same_view(::Transpose, ::Transpose) = true
+same_view(::Adjoint, ::Adjoint) = true
+
+@testset "Respectful similar" begin
+    A0_dense = rand(3, 4)
+    A0_sparse = sprand(rng, 10, 20, 0.3)
+    @test all(matrix_versions(A0_dense)) do A
+        B = respectful_similar(A)
+        size(B) == size(A) && same_view(A, B)
+    end
+    @test all(matrix_versions(A0_sparse)) do A
+        B = respectful_similar(A)
+        size(B) == size(A) && same_view(A, B)
+    end
+end
+
+@testset "Sparsity pattern comparison" begin
+    A = [
+        1 1
+        0 1
+        0 0
+    ]
+    B1 = [
+        1 1
+        0 1
+        1 0
+    ]
+    B2 = [
+        1 1
+        0 0
+        0 1
+    ]
+    C = [
+        1 1 0
+        0 1 0
+        0 0 0
+    ]
+
+    @test same_sparsity_pattern(sparse(A), sparse(A))
+    @test !same_sparsity_pattern(sparse(A), sparse(B1))
+    @test_broken !same_sparsity_pattern(sparse(A), sparse(B2))
+    @test !same_sparsity_pattern(sparse(A), sparse(C))
+
+    @test same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(A)))
+    @test !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(B1)))
+    @test_broken !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(B2)))
+    @test !same_sparsity_pattern(transpose(sparse(A)), transpose(sparse(C)))
+end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ using Test
         @testset "Check" begin
             include("check.jl")
         end
+        @testset "Matrices" begin
+            include("matrices.jl")
+        end
     end
     @testset verbose = true "Correctness" begin
         @testset "Coloring" begin


### PR DESCRIPTION
**Compat**

- Bump version to 0.3.2

**Source**

- Make a new file `matrices.jl` for `respectful_similar`, `same_sparsity_pattern`
- Create `matrix_versions(A)` which lists dense and sparse versions of `A`, with or without `Transpose/Adjoint/Symmetric`
- Simplify checks with `color_groups` and add more precise warnings
- Implement `decompress_symmetric` naively for dense matrices

**Tests**

- Test everywhere on the cartesian product of `matrix_versions(A)` and `matrix_versions(S)`