### PR TITLE
Remove public when export is there

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,13 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        juliaup-channel: ['1.6', '1', 'alpha']
+        julia-version: ['1.6', '1']
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/install-juliaup@v2
+      - uses: julia-actions/setup-julia@v2
         with:
-          channel: ${{ matrix.juliaup-channel }}
+          version: ${{ matrix.julia-version }}
+          arch: x64
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,14 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: ['1.6', '1', 'nightly']
+        juliaup-channel: ['1.6', '1', 'nightly']
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/install-juliaup@v2
         with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
+          channel: ${{ matrix.juliaup-channel }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: ['1.6', '1']
+        julia-version: ['1.6', '1', 'nightly']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        juliaup-channel: ['1.6', '1', 'nightly']
+        juliaup-channel: ['1.6', '1', 'alpha']
 
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle <22795598+gdalle@users.noreply.github.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -41,13 +41,11 @@ include("matrices.jl")
 include("decompression.jl")
 include("check.jl")
 
-@compat public GreedyColoringAlgorithm
 @compat public NaturalOrder, RandomOrder, LargestFirst
 @compat public color_groups
 @compat public decompress_columns, decompress_columns!
 @compat public decompress_rows, decompress_rows!
 @compat public decompress_symmetric, decompress_symmetric!
-@compat public column_coloring, row_coloring, symmetric_coloring
 
 export GreedyColoringAlgorithm
 export column_coloring, row_coloring, symmetric_coloring


### PR DESCRIPTION
- Bump version to v0.3.4

**Source**

- For `GreedyColoringAlgorithm` and the re-exports from ADTypes.jl, remove the `public` annotation since they are already exported