### PR TITLE
Factor out `symmetric_coefficient`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle <22795598+gdalle@users.noreply.github.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -37,6 +37,7 @@ decompress_rows
 decompress_rows!
 decompress_symmetric
 decompress_symmetric!
+symmetric_coefficient
 StarSet
 ```
 

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -46,7 +46,7 @@ include("check.jl")
 @compat public decompress_columns, decompress_columns!
 @compat public decompress_rows, decompress_rows!
 @compat public decompress_symmetric, decompress_symmetric!
-@compat public StarSet
+@compat public symmetric_coefficient, StarSet
 
 export GreedyColoringAlgorithm
 export column_coloring, row_coloring, symmetric_coloring, symmetric_coloring_detailed

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -86,7 +86,7 @@ end
 
 Decompress the small matrix `B` into the tall matrix `A` which must have the same sparsity pattern as `S`.
 
-Here, `color` is a row coloring of `S`, while `B` is a compressed representation of matrix `A` obtained by summing the columns that share the same color.
+Here, `color` is a row coloring of `S`, while `B` is a compressed representation of matrix `A` obtained by summing the rows that share the same color.
 """
 function decompress_rows! end
 
@@ -142,7 +142,7 @@ end
 
 Decompress the small matrix `B` into a new tall matrix `A` with the same sparsity pattern as `S`.
 
-Here, `color` is a row coloring of `S`, while `B` is a compressed representation of matrix `A` obtained by summing the columns that share the same color.
+Here, `color` is a row coloring of `S`, while `B` is a compressed representation of matrix `A` obtained by summing the rows that share the same color.
 """
 function decompress_rows(
     S::AbstractMatrix{Bool}, B::AbstractMatrix{R}, color::AbstractVector{<:Integer}


### PR DESCRIPTION
**Version**

- Bump to v0.3.5

**Source**

- Factor out a `symmetric_coefficient` function which tells us where to find the value of `A[i, j]` in `B`. This function is faster when a `StarSet` is provided.

**Doc**

- Add `symmetric_coefficient` to the public API
- Fix the docstring typo spotted in #26 