### PR TITLE
Update Compat.jl bounds for `stack`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ADTypes = "1.2.1"
-Compat = "3,4"
+Compat = "3.46,4.2"
 DocStringExtensions = "0.9"
 LinearAlgebra = "<0.0.1, 1"
 Random = "<0.0.1, 1"


### PR DESCRIPTION
SparseMatrixColorings imports `stack` from Compat.jl:
https://github.com/gdalle/SparseMatrixColorings.jl/blob/83a1330a025ba2c45b95e144c388380ffec1ace1/src/SparseMatrixColorings.jl#L10

This has only been introduced in versions `3.46.0` and `4.2.0`:
https://github.com/JuliaLang/Compat.jl/blob/f8af0d15a6d8edbbddbae9a7841e38ea518a734f/README.md?plain=1#L95
