### PR TITLE
Downgrade compat in CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
+      - uses: julia-actions/julia-downgrade-compat@v1
+        if: ${{ matrix.version == 'lts' }}
+        with:
+          skip: LinearAlgebra, Random, SparseArrays
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
**DI**

- For LTS tests, downgrade compat bounds to the earliest supported version of every dependency