### PR TITLE
Introduce ColoringProblem

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -79,6 +79,13 @@ SparseMatrixColorings.group_by_color
 SparseMatrixColorings.get_matrix
 ```
 
+### Concrete coloring results
+
+```@docs
+SparseMatrixColorings.DefaultColoringResult
+SparseMatrixColorings.DirectSparseColoringResult
+```
+
 ### Testing
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,13 +11,12 @@ CurrentModule = SparseMatrixColorings
 SparseMatrixColorings
 ```
 
-### Coloring algorithms
+### Entry point
 
 ```@docs
+coloring
+ColoringProblem
 GreedyColoringAlgorithm
-column_coloring_detailed
-row_coloring_detailed
-symmetric_coloring_detailed
 ```
 
 ### Result analysis

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -41,14 +41,14 @@ include("matrices.jl")
 include("interface.jl")
 include("decompression.jl")
 include("check.jl")
+include("sparsematrixcsc.jl")
 
 @compat public NaturalOrder, RandomOrder, LargestFirst
 @compat public decompress, decompress!
 
-export GreedyColoringAlgorithm
-export AbstractColoringResult
+export ColoringProblem, GreedyColoringAlgorithm, AbstractColoringResult
+export coloring
 export column_coloring, row_coloring, symmetric_coloring
-export column_coloring_detailed, row_coloring_detailed, symmetric_coloring_detailed
 export column_colors, row_colors
 export column_groups, row_groups
 

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -2,13 +2,17 @@
     SparseMatrixColorings
 
 $README
+
+## Exports
+
+$EXPORTS
 """
 module SparseMatrixColorings
 
 using ADTypes:
     ADTypes, AbstractColoringAlgorithm, column_coloring, row_coloring, symmetric_coloring
 using Compat: @compat, stack
-using DocStringExtensions: README
+using DocStringExtensions: README, EXPORTS, SIGNATURES, TYPEDEF, TYPEDFIELDS
 using LinearAlgebra:
     Adjoint,
     Diagonal,

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -119,23 +119,22 @@ function star_coloring(g::Graph, order::AbstractOrder)
 end
 
 """
-    StarSet
+$TYPEDEF
 
 Encode a set of 2-colored stars resulting from the star coloring algorithm.
 
 # Fields
 
-The fields are not part of the public API, even though the type is.
-
-- `star::Dict{Tuple{Int,Int},Int}`: a mapping from edges (pair of vertices) their to star index
-- `hub::Vector{Int}`: a mapping from star indices to their hub (the hub is `0` if the star only contains one edge)
+$TYPEDFIELDS
 
 # References
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 4.1
 """
 struct StarSet
+    "a mapping from edges (pair of vertices) their to star index"
     star::Dict{Tuple{Int,Int},Int}
+    "a mapping from star indices to their hub (the hub is `0` if the star only contains one edge)"
     hub::Vector{Int}
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,40 @@
 """
+    ColoringProblem{
+        structure,
+        partition,
+        decompression
+    }
+
+Selector type for the coloring problem to solve, enabling multiple dispatch.
+
+# Constructor
+
+    ColoringProblem(;
+        structure::Symbol=:nonsymmetric,
+        partition::Symbol=:column,
+        decompression::Symbol=:direct,
+    )
+
+# Type parameters
+
+- `structure::Symbol`: either `:nonsymmetric` or `:symmetric`
+- `partition::Symbol`: either `:column`, `:row` or `:bidirectional`
+- `decompression::Symbol`: either `:direct` or `:substitution`
+"""
+struct ColoringProblem{structure,partition,decompression} end
+
+function ColoringProblem(;
+    structure::Symbol=:nonsymmetric,
+    partition::Symbol=:column,
+    decompression::Symbol=:direct,
+)
+    @assert structure in (:nonsymmetric, :symmetric)
+    @assert partition in (:column, :row, :bidirectional)
+    @assert decompression in (:direct, :substitution)
+    return ColoringProblem{structure,partition,decompression}()
+end
+
+"""
     GreedyColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm
 
 Greedy coloring algorithm for sparse Jacobians and Hessians, with configurable vertex order.
@@ -20,19 +56,20 @@ end
 
 GreedyColoringAlgorithm() = GreedyColoringAlgorithm(NaturalOrder())
 
-## Detailed interface
-
 """
-    column_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
+    coloring(
+        S::AbstractMatrix,
+        problem::ColoringProblem,
+        algo::GreedyColoringAlgorithm
+    )
 
-Compute a partial distance-2 coloring of the columns in the bipartite graph of the matrix `S`, return an [`AbstractColoringResult`](@ref).
+Solve the coloring `problem` on matrix `S` with `algo` and return an [`AbstractColoringResult`](@ref).
 
 # Example
 
 ```jldoctest
 julia> using SparseMatrixColorings, SparseArrays
 
-julia> algo = GreedyColoringAlgorithm(SparseMatrixColorings.LargestFirst());
 
 julia> S = sparse([
            0 0 1 1 0
@@ -41,7 +78,11 @@ julia> S = sparse([
            0 1 1 0 1
        ]);
 
-julia> result = column_coloring_detailed(S, algo);
+julia> problem = ColoringProblem(structure=:nonsymmetric, partition=:column);
+
+julia> algo = GreedyColoringAlgorithm(SparseMatrixColorings.LargestFirst());
+
+julia> result = coloring(S, problem, algo);
 
 julia> column_colors(result)
 5-element Vector{Int64}:
@@ -57,139 +98,44 @@ julia> column_groups(result)
  [2, 4]
  [5]
 ```
+
+# See also
+
+- [`ColoringProblem`](@ref)
+- [`GreedyColoringAlgorithm`](@ref)
+- [`AbstractColoringResult`](@ref)
 """
-function column_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
+function coloring end
+
+function coloring(
+    S::AbstractMatrix,
+    ::ColoringProblem{:nonsymmetric,:column,:direct},
+    algo::GreedyColoringAlgorithm,
+)
     bg = bipartite_graph(S)
     color = partial_distance2_coloring(bg, Val(2), algo.order)
-    return SimpleColoringResult{:column,false}(S, color)
+    return DefaultColoringResult{:nonsymmetric,:column,:direct}(S, color)
 end
 
-function column_coloring_detailed(S::SparseMatrixCSC, algo::GreedyColoringAlgorithm)
-    bg = bipartite_graph(S)
-    color = partial_distance2_coloring(bg, Val(2), algo.order)
-    n = size(S, 1)
-    I, J, _ = findnz(S)
-    compressed_indices = zeros(Int, nnz(S))
-    for k in eachindex(I, J, compressed_indices)
-        i, j = I[k], J[k]
-        c = color[j]
-        # A[i, j] = B[i, c]
-        compressed_indices[k] = (c - 1) * n + i
-    end
-    return SparseColoringResult{:column,false}(S, color, compressed_indices)
-end
-
-"""
-    row_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
-
-Compute a partial distance-2 coloring of the rows in the bipartite graph of the matrix `S`, return an [`AbstractColoringResult`](@ref).
-
-# Example
-
-```jldoctest
-julia> using SparseMatrixColorings, SparseArrays
-
-julia> algo = GreedyColoringAlgorithm(SparseMatrixColorings.LargestFirst());
-
-julia> S = sparse([
-           0 0 1 1 0
-           1 0 0 0 1
-           0 1 1 0 0
-           0 1 1 0 1
-       ]);
-
-julia> result = row_coloring_detailed(S, algo);
-
-julia> row_colors(result)
-4-element Vector{Int64}:
- 2
- 2
- 3
- 1
-
-julia> row_groups(result)
-3-element Vector{Vector{Int64}}:
- [4]
- [1, 2]
- [3]
-```
-"""
-function row_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
+function coloring(
+    S::AbstractMatrix,
+    ::ColoringProblem{:nonsymmetric,:row,:direct},
+    algo::GreedyColoringAlgorithm,
+)
     bg = bipartite_graph(S)
     color = partial_distance2_coloring(bg, Val(1), algo.order)
-    return SimpleColoringResult{:row,false}(S, color)
+    return DefaultColoringResult{:nonsymmetric,:row,:direct}(S, color)
 end
 
-function row_coloring_detailed(S::SparseMatrixCSC, algo::GreedyColoringAlgorithm)
-    bg = bipartite_graph(S)
-    color = partial_distance2_coloring(bg, Val(1), algo.order)
-    n = size(S, 1)
-    C = maximum(color)
-    I, J, _ = findnz(S)
-    compressed_indices = zeros(Int, nnz(S))
-    for k in eachindex(I, J, compressed_indices)
-        i, j = I[k], J[k]
-        c = color[i]
-        # A[i, j] = B[c, j]
-        compressed_indices[k] = (j - 1) * C + c
-    end
-    return SparseColoringResult{:row,false}(S, color, compressed_indices)
-end
-
-"""
-    symmetric_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
-
-Compute a star coloring of the columns in the adjacency graph of the symmetric matrix `S`, return an [`AbstractColoringResult`](@ref).
-
-# Example
-
-```jldoctest
-julia> using SparseMatrixColorings, SparseArrays
-
-julia> algo = GreedyColoringAlgorithm(SparseMatrixColorings.LargestFirst());
-
-julia> S = sparse([
-           1 1 1 1
-           1 1 0 0
-           1 0 1 0
-           1 0 0 1
-       ]);
-
-julia> result = symmetric_coloring_detailed(S, algo);
-
-julia> column_colors(result)
-4-element Vector{Int64}:
- 1
- 2
- 2
- 2
-
-julia> column_groups(result)
-2-element Vector{Vector{Int64}}:
- [1]
- [2, 3, 4]
-```
-"""
-function symmetric_coloring_detailed(S::AbstractMatrix, algo::GreedyColoringAlgorithm)
+function coloring(
+    S::AbstractMatrix,
+    ::ColoringProblem{:symmetric,:column,:direct},
+    algo::GreedyColoringAlgorithm,
+)
     ag = adjacency_graph(S)
     color, star_set = star_coloring(ag, algo.order)
     # TODO: handle star_set
-    return SimpleColoringResult{:column,true}(S, color)
-end
-
-function symmetric_coloring_detailed(S::SparseMatrixCSC, algo::GreedyColoringAlgorithm)
-    ag = adjacency_graph(S)
-    color, star_set = star_coloring(ag, algo.order)
-    n = size(S, 1)
-    I, J, _ = findnz(S)
-    compressed_indices = zeros(Int, nnz(S))
-    for k in eachindex(I, J, compressed_indices)
-        i, j = I[k], J[k]
-        l, c = symmetric_coefficient(i, j, color, star_set)
-        # A[i, j] = B[l, c]
-        compressed_indices[k] = (c - 1) * n + l
-    end
-    return SparseColoringResult{:column,true}(S, color, compressed_indices)
+    return DefaultColoringResult{:symmetric,:column,:direct}(S, color)
 end
 
 ## ADTypes interface

--- a/src/result.jl
+++ b/src/result.jl
@@ -83,10 +83,26 @@ end
 
 ## Concrete subtypes
 
+"""
+$TYPEDEF
+
+Default storage for the result of a coloring algorithm, containing minimal information.
+
+# Fields
+
+$TYPEDFIELDS
+
+# See also
+
+- [`AbstractColoringResult`](@ref)
+"""
 struct DefaultColoringResult{structure,partition,decompression,M} <:
        AbstractColoringResult{structure,partition,decompression,M}
+    "matrix that was colored"
     matrix::M
+    "one integer color for each column or row (depending on `partition`)"
     color::Vector{Int}
+    "color groups for columns or rows (depending on `partition`)"
     group::Vector{Vector{Int}}
 end
 

--- a/src/sparsematrixcsc.jl
+++ b/src/sparsematrixcsc.jl
@@ -1,10 +1,27 @@
 ## Result
 
+"""
+$TYPEDEF
+
+Storage for the result of a coloring algorithm when the decompression target is a `SparseMatrixCSC`.
+
+# Fields
+
+$TYPEDFIELDS
+
+# See also
+
+- [`AbstractColoringResult`](@ref)
+"""
 struct DirectSparseColoringResult{structure,partition,M} <:
        AbstractColoringResult{structure,partition,:direct,M}
+    "matrix that was colored"
     matrix::M
+    "one integer color for each column or row (depending on `partition`)"
     color::Vector{Int}
+    "color groups for columns or rows (depending on `partition`)"
     group::Vector{Vector{Int}}
+    "flattened indices mapping the compressed matrix `B` to the uncompressed matrix `A`: they satisfy `nonzeros(A)[k] = vec(B)[compressed_indices[k]]`"
     compressed_indices::Vector{Int}
 end
 

--- a/src/sparsematrixcsc.jl
+++ b/src/sparsematrixcsc.jl
@@ -1,0 +1,98 @@
+## Result
+
+struct DirectSparseColoringResult{structure,partition,M} <:
+       AbstractColoringResult{structure,partition,:direct,M}
+    matrix::M
+    color::Vector{Int}
+    group::Vector{Vector{Int}}
+    compressed_indices::Vector{Int}
+end
+
+function DirectSparseColoringResult{structure,partition}(
+    matrix::M, color::Vector{Int}, compressed_indices::Vector{Int}
+) where {structure,partition,M}
+    return DirectSparseColoringResult{structure,partition,M}(
+        matrix, color, group_by_color(color), compressed_indices
+    )
+end
+
+get_matrix(result::DirectSparseColoringResult) = result.matrix
+
+column_colors(result::DirectSparseColoringResult{s,:column}) where {s} = result.color
+column_groups(result::DirectSparseColoringResult{s,:column}) where {s} = result.group
+
+row_colors(result::DirectSparseColoringResult{s,:row}) where {s} = result.color
+row_groups(result::DirectSparseColoringResult{s,:row}) where {s} = result.group
+
+## Coloring
+
+function coloring(
+    S::SparseMatrixCSC,
+    ::ColoringProblem{:nonsymmetric,:column,:direct},
+    algo::GreedyColoringAlgorithm,
+)
+    bg = bipartite_graph(S)
+    color = partial_distance2_coloring(bg, Val(2), algo.order)
+    n = size(S, 1)
+    I, J, _ = findnz(S)
+    compressed_indices = zeros(Int, nnz(S))
+    for k in eachindex(I, J, compressed_indices)
+        i, j = I[k], J[k]
+        c = color[j]
+        # A[i, j] = B[i, c]
+        compressed_indices[k] = (c - 1) * n + i
+    end
+    return DirectSparseColoringResult{:nonsymmetric,:column}(S, color, compressed_indices)
+end
+
+function coloring(
+    S::SparseMatrixCSC,
+    ::ColoringProblem{:nonsymmetric,:row,:direct},
+    algo::GreedyColoringAlgorithm,
+)
+    bg = bipartite_graph(S)
+    color = partial_distance2_coloring(bg, Val(1), algo.order)
+    n = size(S, 1)
+    C = maximum(color)
+    I, J, _ = findnz(S)
+    compressed_indices = zeros(Int, nnz(S))
+    for k in eachindex(I, J, compressed_indices)
+        i, j = I[k], J[k]
+        c = color[i]
+        # A[i, j] = B[c, j]
+        compressed_indices[k] = (j - 1) * C + c
+    end
+    return DirectSparseColoringResult{:nonsymmetric,:row}(S, color, compressed_indices)
+end
+
+function symmetric_coloring_detailed(
+    S::SparseMatrixCSC,
+    ::ColoringProblem{:symmetric,:column,:direct},
+    algo::GreedyColoringAlgorithm,
+)
+    ag = adjacency_graph(S)
+    color, star_set = star_coloring(ag, algo.order)
+    n = size(S, 1)
+    I, J, _ = findnz(S)
+    compressed_indices = zeros(Int, nnz(S))
+    for k in eachindex(I, J, compressed_indices)
+        i, j = I[k], J[k]
+        l, c = symmetric_coefficient(i, j, color, star_set)
+        # A[i, j] = B[l, c]
+        compressed_indices[k] = (c - 1) * n + l
+    end
+    return DirectSparseColoringResult{:symmetric,:column}(S, color, compressed_indices)
+end
+
+## Decompression
+
+function decompress_aux!(
+    A::SparseMatrixCSC{R}, B::AbstractMatrix{R}, result::DirectSparseColoringResult
+) where {R<:Real}
+    nzA = nonzeros(A)
+    ind = result.compressed_indices
+    for i in eachindex(nzA, ind)
+        nzA[i] = B[ind[i]]
+    end
+    return A
+end

--- a/src/sparsematrixcsc.jl
+++ b/src/sparsematrixcsc.jl
@@ -65,7 +65,7 @@ function coloring(
     return DirectSparseColoringResult{:nonsymmetric,:row}(S, color, compressed_indices)
 end
 
-function symmetric_coloring_detailed(
+function coloring(
     S::SparseMatrixCSC,
     ::ColoringProblem{:symmetric,:column,:direct},
     algo::GreedyColoringAlgorithm,

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -6,7 +6,6 @@ using SparseMatrixColorings
 using SparseMatrixColorings:
     adjacency_graph,
     bipartite_graph,
-    decompress_aux!,
     decompress!,
     partial_distance2_coloring!,
     respectful_similar
@@ -24,6 +23,7 @@ rng = StableRNG(63)
     @test_opt target_modules = (SparseMatrixColorings,) symmetric_coloring(
         Symmetric(A), algo
     )
+    @test_opt target_modules = (SparseMatrixColorings,) coloring(A, ColoringProblem(), algo)
 end
 
 function benchmark_distance2_coloring(n)
@@ -42,7 +42,11 @@ end
 
 function benchmark_sparse_decompression(n)
     A = sprand(n, 2n, 5 / n)
-    result = column_coloring_detailed(A, GreedyColoringAlgorithm())
+    result = coloring(
+        A,
+        ColoringProblem(; structure=:nonsymmetric, partition=:column),
+        GreedyColoringAlgorithm(),
+    )
     group = column_groups(result)
     B = stack(group; dims=2) do g
         dropdims(sum(A[:, g]; dims=2); dims=2)

--- a/test/random.jl
+++ b/test/random.jl
@@ -4,7 +4,6 @@ using LinearAlgebra: I, Symmetric
 using SparseArrays: sprand
 using SparseMatrixColorings
 using SparseMatrixColorings:
-    GreedyColoringAlgorithm,
     structurally_orthogonal_columns,
     symmetrically_orthogonal_columns,
     directly_recoverable_columns,
@@ -30,10 +29,13 @@ symmetric_params = vcat(
 )
 
 @testset "Column coloring & decompression" begin
+    problem = ColoringProblem(;
+        structure=:nonsymmetric, partition=:column, decompression=:direct
+    )
     @testset "Size ($m, $n) - sparsity $p" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         @testset "A::$(typeof(A))" for A in matrix_versions(A0)
-            result = column_coloring_detailed(A, algo)
+            result = coloring(A, problem, algo)
             color = column_colors(result)
             group = column_groups(result)
             @test color == column_coloring(A, algo)
@@ -49,10 +51,13 @@ symmetric_params = vcat(
 end;
 
 @testset "Row coloring & decompression" begin
+    problem = ColoringProblem(;
+        structure=:nonsymmetric, partition=:row, decompression=:direct
+    )
     @testset "Size ($m, $n) - sparsity $p" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         @testset "A::$(typeof(A))" for A in matrix_versions(A0)
-            result = row_coloring_detailed(A, algo)
+            result = coloring(A, problem, algo)
             color = row_colors(result)
             group = row_groups(result)
             @test color == row_coloring(A, algo)
@@ -68,11 +73,14 @@ end;
 end;
 
 @testset "Symmetric coloring & decompression" begin
+    problem = ColoringProblem(;
+        structure=:symmetric, partition=:column, decompression=:direct
+    )
     @testset "Size ($n, $n) - sparsity $p" for (n, p) in symmetric_params
         A0 = Symmetric(sprand(rng, n, n, p))
         @testset "A::$(typeof(A))" for A in matrix_versions(A0)
             # Naive decompression
-            result = symmetric_coloring_detailed(A, algo)
+            result = coloring(A, problem, algo)
             color = column_colors(result)
             group = column_groups(result)
             @test color == symmetric_coloring(A, algo)

--- a/test/small.jl
+++ b/test/small.jl
@@ -4,17 +4,13 @@ using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings
 using SparseMatrixColorings:
-    SimpleColoringResult,
+    DefaultColoringResult,
     decompress,
     decompress!,
     group_by_color,
     matrix_versions,
-    respectful_similar,
-    same_sparsity_pattern
-using StableRNGs
+    respectful_similar
 using Test
-
-rng = StableRNG(63)
 
 algo = GreedyColoringAlgorithm()
 
@@ -31,7 +27,7 @@ algo = GreedyColoringAlgorithm()
         5 0
     ]
     color = [1, 1, 2]
-    result = SimpleColoringResult{:column,false}(A0, color)
+    result = DefaultColoringResult{:nonsymmetric,:column,:direct}(A0, color)
     @test decompress(B, result) == A0
     for A in matrix_versions(A0)
         @test decompress!(respectful_similar(A), B, result) == A
@@ -49,7 +45,7 @@ end;
         4 5 0
     ]
     color = [1, 1, 2]
-    result = SimpleColoringResult{:row,false}(A0, color)
+    result = DefaultColoringResult{:nonsymmetric,:row,:direct}(A0, color)
     @test decompress(B, result) == A0
     for A in matrix_versions(A0)
         @test decompress!(respectful_similar(A), B, result) == A
@@ -67,7 +63,7 @@ end;
             1,  # green
             1,  # green
         ]
-        result = SimpleColoringResult{:column,true}(A0, color)
+        result = DefaultColoringResult{:symmetric,:column,:direct}(A0, color)
         group = group_by_color(color)
         B = stack(group; dims=2) do g
             dropdims(sum(A0[:, g]; dims=2); dims=2)
@@ -92,7 +88,7 @@ end;
             1,  # red
             2,  # blue
         ]
-        result = SimpleColoringResult{:column,true}(A0, color)
+        result = DefaultColoringResult{:symmetric,:column,:direct}(A0, color)
         group = group_by_color(color)
         B = stack(group; dims=2) do g
             dropdims(sum(A0[:, g]; dims=2); dims=2)


### PR DESCRIPTION
- [x] Merge `column_coloring_detailed`, `row_coloring_detailed` and `symmetric_coloring_detailed` into a single function `coloring`.
- [x] Dispatch on the right version thanks to a new `ColoringProblem{structure,partition,decompression}` type, where `structure in (:nonsymmetric, :symmetric)`, `partition in (:column, :row, :bidirectional)` and `decompression in (:direct, :substitution)`.
- [x] Adjust `AbstractColoringResult` and its subtypes to reflect the parameters of `ColoringProblem`.
- [x] Isolate the code necessary for decompression into `SparseMatrixCSC`, so that other matrix types can be easily added.
- [x] Update tests and docs.