### PR TITLE
Don't export ADTypes interface

### DIFF
--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -9,8 +9,7 @@ $EXPORTS
 """
 module SparseMatrixColorings
 
-using ADTypes:
-    ADTypes, AbstractColoringAlgorithm, column_coloring, row_coloring, symmetric_coloring
+using ADTypes: ADTypes
 using Compat: @compat, stack
 using DocStringExtensions: README, EXPORTS, SIGNATURES, TYPEDEF, TYPEDFIELDS
 using LinearAlgebra:
@@ -53,7 +52,6 @@ include("examples.jl")
 
 export ColoringProblem, GreedyColoringAlgorithm, AbstractColoringResult
 export coloring
-export column_coloring, row_coloring, symmetric_coloring
 export column_colors, row_colors
 export column_groups, row_groups
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Chairmarks = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"

--- a/test/colpack.jl
+++ b/test/colpack.jl
@@ -1,3 +1,4 @@
+using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using ColPack: ColPack, ColPackColoring
 using LinearAlgebra
 using SparseMatrixColorings

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -1,3 +1,4 @@
+using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using Chairmarks
 using JET
 using LinearAlgebra

--- a/test/random.jl
+++ b/test/random.jl
@@ -1,3 +1,4 @@
+using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using Base.Iterators: product
 using Compat
 using LinearAlgebra: I, Symmetric

--- a/test/small.jl
+++ b/test/small.jl
@@ -1,3 +1,4 @@
+using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using Base.Iterators: product
 using Compat
 using LinearAlgebra

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -1,3 +1,4 @@
+using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using CSV
 using DataFrames
 using LinearAlgebra


### PR DESCRIPTION
- Remove re-exports of `column_coloring`, `row_coloring` and `symmetric_coloring`
- Adjust tests