### PR TITLE
Improve the decompression for acyclic coloring

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -99,7 +99,7 @@ function decompress_aux!(
 ) where {R<:Real}
     # build T such that T * strict_upper_nonzeros(A) = B
     # and solve a linear least-squares problem
-    # only consider the strict lower triangle of A because of symmetry
+    # only consider the strict upper triangle of A because of symmetry
     # TODO: make more efficient
     A .= zero(R)
     S = sparse(get_matrix(result))


### PR DESCRIPTION
We know that diagonal coefficients of `A` are not combined with other coefficients in the compressed matrix `B`.
`T` can have less columns thanks to that.

I also fixed a comment, we store the lower triangular of `A` and not its upper triangular part.