### PR TITLE
Implement `TreeSet`-based acyclic decompression

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -315,7 +315,7 @@ function decompress_aux!(
     trees = [Int[] for i in 1:ntrees]
 
     # dictionary that maps a tree's root to the index of the tree
-    roots = Dict{Int, Int}()
+    roots = Dict{Int,Int}()
 
     k = 0
     for edge in forest.revmap
@@ -359,7 +359,7 @@ function decompress_aux!(
                         degree[i] -= 1  # decrease the degree of vertex i
                         degree[j] -= 1  # decrease the degree of vertex j
                         tree[t] = 0  # remove the edge (i,j)
-                        push!(dfs_orders[k], (i,j))
+                        push!(dfs_orders[k], (i, j))
                     end
                 end
             end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -22,10 +22,12 @@ function test_coloring_decompression(
         B = compress(A, result)
         !isnothing(color0) && @test color == color0
         !isnothing(B0) && @test B == B0
-        @test decompress(B, result) ≈ A0
         @test decompress(B, default_result) ≈ A0
-        @test decompress!(respectful_similar(A), B, result) ≈ A0
+        @test decompress(B, result) ≈ A0
+        @test decompress(B, result) ≈ A0  # check result wasn't modified
         @test decompress!(respectful_similar(A), B, default_result) ≈ A0
+        @test decompress!(respectful_similar(A), B, result) ≈ A0
+        @test decompress!(respectful_similar(A), B, result) ≈ A0
     end
     @test all(color_vec .== Ref(color_vec[1]))
 end


### PR DESCRIPTION
@gdalle The optimized version of the acyclic coloring is finally working! :muscle: 
I was able to verify it on this example:
```julia
using SparseMatrixColorings

A = Float64[
   1  2  0  0  0  0  3  0  0  0
   2  4  5  0  6  0  0  0  0  0
   0  5  7  8  0  9  0  0  0  0
   0  0  8  10 0  0  0  0  0  11
   0  6  0  0  12 13 0  14 0  0
   0  0  9  0  13 15 0  0  16 0
   3  0  0  0  0  0  17 18 0  0
   0  0  0  0  14 0  18 19 20 0
   0  0  0  0  0  16 0  20 21 22
   0  0  0  11 0  0  0  0  22 23
] |> sparse

g = SparseMatrixColorings.Graph(A - Diagonal(A))
order = SparseMatrixColorings.NaturalOrder()

colors, tree_set = SparseMatrixColorings.acyclic_coloring(g, order)

result = coloring(
            A,
            ColoringProblem(;
                structure=:symmetric, partition=:column, decompression=:substitution
            ),
            GreedyColoringAlgorithm(),
        )
column_colors(result)

@test colors == [1, 2, 1, 2, 1, 3, 2, 3, 2, 1]

S = map(!iszero, A)
S = Float64.(S)
A0 = copy(A)
B = [
                            A0[1,1]    A0[1,2]+A0[1,7]                0
            A0[2,1]+A0[2,3]+A0[2,5]            A0[2,2]                0
                            A0[3,3]    A0[3,2]+A0[3,4]          A0[3,6]
                   A0[4,3]+A0[4,10]            A0[4,4]                0
                            A0[5,5]            A0[5,2]  A0[5,6]+A0[5,8]
                    A0[6,3]+A0[6,5]            A0[6,9]          A0[6,6]
                            A0[7,1]            A0[7,7]          A0[7,8]
                            A0[8,5]    A0[8,7]+A0[8,9]          A0[8,8]
                           A0[9,10]            A0[9,9]  A0[9,6]+A0[9,8]
                          A0[10,10]  A0[10,4]+A0[10,9]                0
        ]

A2 = SparseMatrixColorings.decompress_acyclic!(S, B, colors, tree_set)
```