### PR TITLE
Export decompress and split API docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ makedocs(;
     authors="Guillaume Dalle",
     sitename="SparseMatrixColorings.jl",
     format=Documenter.HTML(),
-    pages=["Home" => "index.md", "API reference" => "api.md"],
+    pages=["Home" => "index.md", "api.md", "dev.md"],
     plugins=[links],
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,13 +5,13 @@ CollapsedDocStrings = true
 CurrentModule = SparseMatrixColorings
 ```
 
-## Public, exported
-
 ```@docs
 SparseMatrixColorings
 ```
 
-### Main function
+The docstrings on this page define the public API of the package.
+
+## Main function
 
 ```@docs
 coloring
@@ -19,7 +19,7 @@ ColoringProblem
 GreedyColoringAlgorithm
 ```
 
-### Result analysis
+## Result analysis
 
 ```@docs
 AbstractColoringResult
@@ -29,79 +29,20 @@ column_groups
 row_groups
 ```
 
-## Public, not exported
-
-### Decompression
+## Decompression
 
 ```@docs
 decompress
 decompress!
 ```
 
-### Orders
+## Orders
+
+These symbols are not exported but they are still part of the public API.
 
 ```@docs
 AbstractOrder
 NaturalOrder
 RandomOrder
 LargestFirst
-```
-
-## Private
-
-### Graph storage
-
-```@docs
-SparseMatrixColorings.Graph
-SparseMatrixColorings.BipartiteGraph
-SparseMatrixColorings.vertices
-SparseMatrixColorings.neighbors
-SparseMatrixColorings.adjacency_graph
-SparseMatrixColorings.bipartite_graph
-```
-
-### Low-level coloring
-
-```@docs
-SparseMatrixColorings.partial_distance2_coloring
-SparseMatrixColorings.symmetric_coefficient
-SparseMatrixColorings.star_coloring
-SparseMatrixColorings.acyclic_coloring
-SparseMatrixColorings.group_by_color
-SparseMatrixColorings.get_matrix
-SparseMatrixColorings.StarSet
-SparseMatrixColorings.TreeSet
-```
-
-### Concrete coloring results
-
-```@docs
-SparseMatrixColorings.DefaultColoringResult
-SparseMatrixColorings.DirectSparseColoringResult
-```
-
-### Testing
-
-```@docs
-SparseMatrixColorings.same_sparsity_pattern
-SparseMatrixColorings.directly_recoverable_columns
-SparseMatrixColorings.symmetrically_orthogonal_columns
-SparseMatrixColorings.structurally_orthogonal_columns
-```
-
-### Matrix handling
-
-```@docs
-SparseMatrixColorings.respectful_similar
-SparseMatrixColorings.matrix_versions
-```
-
-### Examples
-
-```@docs
-SparseMatrixColorings.Example
-SparseMatrixColorings.what_fig_41
-SparseMatrixColorings.what_fig_61
-SparseMatrixColorings.efficient_fig_1
-SparseMatrixColorings.efficient_fig_4
 ```

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -1,0 +1,65 @@
+# Dev docs
+
+```@meta
+CollapsedDocStrings = true
+CurrentModule = SparseMatrixColorings
+```
+
+The docstrings on this page describe internals, they are not part of the public API.
+
+## Graph storage
+
+```@docs
+SparseMatrixColorings.Graph
+SparseMatrixColorings.BipartiteGraph
+SparseMatrixColorings.vertices
+SparseMatrixColorings.neighbors
+SparseMatrixColorings.adjacency_graph
+SparseMatrixColorings.bipartite_graph
+```
+
+## Low-level coloring
+
+```@docs
+SparseMatrixColorings.partial_distance2_coloring
+SparseMatrixColorings.symmetric_coefficient
+SparseMatrixColorings.star_coloring
+SparseMatrixColorings.acyclic_coloring
+SparseMatrixColorings.group_by_color
+SparseMatrixColorings.get_matrix
+SparseMatrixColorings.StarSet
+SparseMatrixColorings.TreeSet
+```
+
+## Concrete coloring results
+
+```@docs
+SparseMatrixColorings.DefaultColoringResult
+SparseMatrixColorings.DirectSparseColoringResult
+```
+
+## Testing
+
+```@docs
+SparseMatrixColorings.same_sparsity_pattern
+SparseMatrixColorings.directly_recoverable_columns
+SparseMatrixColorings.symmetrically_orthogonal_columns
+SparseMatrixColorings.structurally_orthogonal_columns
+```
+
+## Matrix handling
+
+```@docs
+SparseMatrixColorings.respectful_similar
+SparseMatrixColorings.matrix_versions
+```
+
+## Examples
+
+```@docs
+SparseMatrixColorings.Example
+SparseMatrixColorings.what_fig_41
+SparseMatrixColorings.what_fig_61
+SparseMatrixColorings.efficient_fig_1
+SparseMatrixColorings.efficient_fig_4
+```

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -49,11 +49,11 @@ include("sparsematrixcsc.jl")
 include("examples.jl")
 
 @compat public NaturalOrder, RandomOrder, LargestFirst
-@compat public decompress, decompress!
 
 export ColoringProblem, GreedyColoringAlgorithm, AbstractColoringResult
 export coloring
 export column_colors, row_colors
 export column_groups, row_groups
+export decompress, decompress!
 
 end

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -5,11 +5,7 @@ using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings
 using SparseMatrixColorings:
-    adjacency_graph,
-    bipartite_graph,
-    decompress!,
-    partial_distance2_coloring!,
-    respectful_similar
+    adjacency_graph, bipartite_graph, partial_distance2_coloring!, respectful_similar
 using StableRNGs
 using Test
 

--- a/test/small.jl
+++ b/test/small.jl
@@ -6,8 +6,6 @@ using SparseArrays
 using SparseMatrixColorings
 using SparseMatrixColorings:
     DefaultColoringResult,
-    decompress,
-    decompress!,
     group_by_color,
     structurally_orthogonal_columns,
     symmetrically_orthogonal_columns,


### PR DESCRIPTION
- Export `decompress` and `decompress!`
- Split API reference between a public and a private page (called "dev docs")