### PR TITLE
Make type-stable constructors part of the API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,11 +5,11 @@ CollapsedDocStrings = true
 CurrentModule = SparseMatrixColorings
 ```
 
+The docstrings on this page define the public API of the package.
+
 ```@docs
 SparseMatrixColorings
 ```
-
-The docstrings on this page define the public API of the package.
 
 ## Main function
 
@@ -38,8 +38,6 @@ decompress!
 ```
 
 ## Orders
-
-These symbols are not exported but they are still part of the public API.
 
 ```@docs
 AbstractOrder

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -43,7 +43,6 @@ SparseMatrixColorings.LinearSystemColoringResult
 ## Testing
 
 ```@docs
-SparseMatrixColorings.same_sparsity_pattern
 SparseMatrixColorings.directly_recoverable_columns
 SparseMatrixColorings.symmetrically_orthogonal_columns
 SparseMatrixColorings.structurally_orthogonal_columns
@@ -54,6 +53,7 @@ SparseMatrixColorings.structurally_orthogonal_columns
 ```@docs
 SparseMatrixColorings.respectful_similar
 SparseMatrixColorings.matrix_versions
+SparseMatrixColorings.same_pattern
 ```
 
 ## Examples

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -49,12 +49,11 @@ include("decompression.jl")
 include("check.jl")
 include("examples.jl")
 
+export NaturalOrder, RandomOrder, LargestFirst
 export ColoringProblem, GreedyColoringAlgorithm, AbstractColoringResult
 export coloring
 export column_colors, row_colors
 export column_groups, row_groups
 export compress, decompress, decompress!
-
-@compat public NaturalOrder, RandomOrder, LargestFirst
 
 end

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -181,27 +181,16 @@ true
 - [`ColoringProblem`](@ref)
 - [`AbstractColoringResult`](@ref)
 """
-function decompress!(
-    A::AbstractMatrix{R},
-    B::AbstractMatrix{R},
-    result::AbstractColoringResult{structure,partition,decompression},
-) where {R<:Real,structure,partition,decompression}
-    # common checks
-    S = get_matrix(result)
-    structure == :symmetric && checksquare(A)
-    if !same_sparsity_pattern(A, S)
-        throw(DimensionMismatch("`A` and `S` must have the same sparsity pattern."))
-    end
-    return decompress_aux!(A, B, result)
-end
+function decompress! end
 
 ## NonSymmetricColoringResult
 
-function decompress_aux!(
+function decompress!(
     A::AbstractMatrix{R}, B::AbstractMatrix{R}, result::NonSymmetricColoringResult{:column}
 ) where {R<:Real}
-    A .= zero(R)
     S = get_matrix(result)
+    check_same_pattern(A, S)
+    A .= zero(R)
     color = column_colors(result)
     rvS = rowvals(S)
     for j in axes(S, 2)
@@ -214,11 +203,12 @@ function decompress_aux!(
     return A
 end
 
-function decompress_aux!(
+function decompress!(
     A::AbstractMatrix{R}, B::AbstractMatrix{R}, result::NonSymmetricColoringResult{:row}
 ) where {R<:Real}
-    A .= zero(R)
     S = get_matrix(result)
+    check_same_pattern(A, S)
+    A .= zero(R)
     color = row_colors(result)
     rvS = rowvals(S)
     for j in axes(S, 2)
@@ -231,9 +221,11 @@ function decompress_aux!(
     return A
 end
 
-function decompress_aux!(
+function decompress!(
     A::SparseMatrixCSC{R}, B::AbstractMatrix{R}, result::NonSymmetricColoringResult{:column}
 ) where {R<:Real}
+    S = get_matrix(result)
+    check_same_pattern(A, S)
     nzA = nonzeros(A)
     ind = result.compressed_indices
     for i in eachindex(nzA, ind)
@@ -242,9 +234,11 @@ function decompress_aux!(
     return A
 end
 
-function decompress_aux!(
+function decompress!(
     A::SparseMatrixCSC{R}, B::AbstractMatrix{R}, result::NonSymmetricColoringResult{:row}
 ) where {R<:Real}
+    S = get_matrix(result)
+    check_same_pattern(A, S)
     nzA = nonzeros(A)
     ind = result.compressed_indices
     for i in eachindex(nzA, ind)
@@ -255,11 +249,12 @@ end
 
 ## StarSetColoringResult
 
-function decompress_aux!(
+function decompress!(
     A::AbstractMatrix{R}, B::AbstractMatrix{R}, result::StarSetColoringResult
 ) where {R<:Real}
-    A .= zero(R)
     S = get_matrix(result)
+    check_same_pattern(A, S)
+    A .= zero(R)
     color = column_colors(result)
     rvS = rowvals(S)
     for j in axes(S, 2)
@@ -272,9 +267,11 @@ function decompress_aux!(
     return A
 end
 
-function decompress_aux!(
+function decompress!(
     A::SparseMatrixCSC{R}, B::AbstractMatrix{R}, result::StarSetColoringResult
 ) where {R<:Real}
+    S = get_matrix(result)
+    check_same_pattern(A, S)
     nzA = nonzeros(A)
     ind = result.compressed_indices
     for i in eachindex(nzA, ind)
@@ -287,11 +284,12 @@ end
 
 # TODO: add method for A::SparseMatrixCSC
 
-function decompress_aux!(
+function decompress!(
     A::AbstractMatrix{R}, B::AbstractMatrix{R}, result::TreeSetColoringResult
 ) where {R<:Real}
-    A .= zero(R)
     S = get_matrix(result)
+    check_same_pattern(A, S)
+    A .= zero(R)
     color = column_colors(result)
     @compat (; vertices_by_tree, reverse_bfs_orders, buffer) = result
 
@@ -326,10 +324,11 @@ end
 
 ## MatrixInverseColoringResult
 
-function decompress_aux!(
+function decompress!(
     A::AbstractMatrix{R}, B::AbstractMatrix{R}, result::LinearSystemColoringResult
 ) where {R<:Real}
     S = get_matrix(result)
+    check_same_pattern(A, S)
     color = column_colors(result)
     @compat (; strict_upper_nonzero_inds, T_factorization, strict_upper_nonzeros_A) = result
 

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -46,24 +46,23 @@ function respectful_similar(A::Adjoint, ::Type{T}) where {T}
 end
 
 """
-    same_sparsity_pattern(A::AbstractMatrix, B::AbstractMatrix)
+    same_pattern(A::AbstractMatrix, B::AbstractMatrix)
 
 Perform a partial equality check on the sparsity patterns of `A` and `B`:
 
 - if the return is `true`, they might have the same sparsity pattern but we're not sure
 - if the return is `false`, they definitely don't have the same sparsity pattern
 """
-function same_sparsity_pattern(A::AbstractMatrix, B::AbstractMatrix)
+function same_pattern(A::AbstractMatrix, B::AbstractMatrix)
     return size(A) == size(B)
 end
 
-function same_sparsity_pattern(A::SparseMatrixCSC, B::SparseMatrixCSC)
+function same_pattern(A::SparseMatrixCSC, B::SparseMatrixCSC)
     return size(A) == size(B) && nnz(A) == nnz(B)
 end
 
-function same_sparsity_pattern(
-    A::TransposeOrAdjoint{<:Any,<:SparseMatrixCSC},
-    B::TransposeOrAdjoint{<:Any,<:SparseMatrixCSC},
-)
-    return same_sparsity_pattern(parent(A), parent(B))
+function check_same_pattern(A::AbstractMatrix, S::AbstractMatrix)
+    if !same_pattern(A, S)
+        throw(DimensionMismatch("`A` and `S` must have the same sparsity pattern."))
+    end
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,0 +1,15 @@
+using SparseMatrixColorings
+using Test
+
+@test ColoringProblem{:nonsymmetric,:column}() == ColoringProblem()
+@test ColoringProblem{:symmetric,:column}() ==
+    ColoringProblem(; structure=:symmetric, partition=:column)
+
+@test_throws ArgumentError ColoringProblem(; structure=:weird, partition=:column)
+@test_throws ArgumentError ColoringProblem(; structure=:symmetric, partition=:row)
+
+@test GreedyColoringAlgorithm{:direct}() == GreedyColoringAlgorithm()
+@test GreedyColoringAlgorithm{:substitution}() ==
+    GreedyColoringAlgorithm(; decompression=:substitution)
+
+@test_throws ArgumentError GreedyColoringAlgorithm(decompression=:weird)

--- a/test/matrices.jl
+++ b/test/matrices.jl
@@ -1,5 +1,7 @@
+using LinearAlgebra
 using SparseArrays
-using SparseMatrixColorings: matrix_versions, respectful_similar, same_sparsity_pattern
+using SparseMatrixColorings:
+    check_same_pattern, matrix_versions, respectful_similar, same_pattern
 using StableRNGs
 using Test
 
@@ -29,4 +31,22 @@ same_view(::Adjoint, ::Adjoint) = true
         B = respectful_similar(A)
         size(B) == size(A) && same_view(A, B)
     end
+end
+
+@testset "Sparsity pattern" begin
+    S = sparse([
+        0 1 1
+        0 1 0
+        1 1 0
+    ])
+
+    A1 = copy(S)
+    A2 = copy(S)
+    A2[1, 1] = 1
+
+    @test same_pattern(A1, S)
+    @test !same_pattern(A2, S)
+    @test same_pattern(Matrix(A2), S)
+
+    @test_throws DimensionMismatch check_same_pattern(A2, S)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,9 @@ include("utils.jl")
         @testset "Matrices" begin
             include("matrices.jl")
         end
+        @testset "Constructors" begin
+            include("constructors.jl")
+        end
     end
     @testset verbose = true "Correctness" begin
         @testset "Small instances" begin


### PR DESCRIPTION
- Make `ColoringProblem{structure,partition}()` and `GreedyColoringAlgorithm{decompression}(order)` part of the public API. Document that the other constructors (based on keyword arguments) are type-unstable. Add a few more consistency checks for these constructors.
- Export the names `NaturalOrder`, `RandomOrder` and `LargestFirst`.
- Remove `decompress_aux!` so that the various methods for `decompress!` are visible to users.