### PR TITLE
Add option to decompress into a triangle only

### DIFF
--- a/test/random.jl
+++ b/test/random.jl
@@ -1,6 +1,5 @@
 using ADTypes: column_coloring, row_coloring, symmetric_coloring
-using Compat
-using LinearAlgebra: I, Symmetric
+using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings
 using SparseMatrixColorings:
@@ -27,7 +26,7 @@ symmetric_params = vcat(
 @testset "Column coloring & decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
     algo = GreedyColoringAlgorithm(; decompression=:direct)
-    for (m, n, p) in asymmetric_params
+    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         color0 = column_coloring(A0, algo)
         @test structurally_orthogonal_columns(A0, color0)
@@ -39,7 +38,7 @@ end;
 @testset "Row coloring & decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:row)
     algo = GreedyColoringAlgorithm(; decompression=:direct)
-    for (m, n, p) in asymmetric_params
+    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         color0 = row_coloring(A0, algo)
         @test structurally_orthogonal_columns(transpose(A0), color0)
@@ -51,8 +50,8 @@ end;
 @testset "Symmetric coloring & direct decompression" begin
     problem = ColoringProblem(; structure=:symmetric, partition=:column)
     algo = GreedyColoringAlgorithm(; decompression=:direct)
-    for (n, p) in symmetric_params
-        A0 = Symmetric(sprand(rng, n, n, p))
+    @testset "$((; n, p))" for (n, p) in symmetric_params
+        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         color0 = symmetric_coloring(A0, algo)
         @test symmetrically_orthogonal_columns(A0, color0)
         @test directly_recoverable_columns(A0, color0)
@@ -63,8 +62,8 @@ end;
 @testset "Symmetric coloring & substitution decompression" begin
     problem = ColoringProblem(; structure=:symmetric, partition=:column)
     algo = GreedyColoringAlgorithm(; decompression=:substitution)
-    for (n, p) in symmetric_params
-        A0 = Symmetric(sprand(rng, n, n, p))
+    @testset "$((; n, p))" for (n, p) in symmetric_params
+        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         # TODO: find tests for recoverability
         test_coloring_decompression(A0, problem, algo)
     end

--- a/test/small.jl
+++ b/test/small.jl
@@ -1,5 +1,3 @@
-using Compat
-using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings
 using SparseMatrixColorings:

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -21,55 +21,84 @@ function test_coloring_decompression(
         push!(color_vec, color)
 
         B = compress(A, result)
-        !isnothing(color0) && @test color == color0
-        !isnothing(B0) && @test B == B0
 
-        # Full decompression
-        @test decompress(B, result) ≈ A0
-        @test decompress(B, result) ≈ A0  # check result wasn't modified
-        @test decompress!(respectful_similar(A), B, result) ≈ A0
-        @test decompress!(respectful_similar(A), B, result) ≈ A0
+        @testset "Reference" begin
+            !isnothing(color0) && @test color == color0
+            !isnothing(B0) && @test B == B0
+        end
 
-        # Colorwise decompression
-        if decompression == :direct  # TODO: implement for :substitution too
-            A2 = respectful_similar(A)
-            A2 .= zero(eltype(A2))
-            for c in unique(color)
-                if partition == :column
-                    decompress_single_color!(A2, B[:, c], c, result)
-                elseif partition == :row
-                    decompress_single_color!(A2, B[c, :], c, result)
+        @testset "Full decompression" begin
+            @test decompress(B, result) ≈ A0
+            @test decompress(B, result) ≈ A0  # check result wasn't modified
+            @test decompress!(respectful_similar(A), B, result) ≈ A0
+            @test decompress!(respectful_similar(A), B, result) ≈ A0
+        end
+
+        @testset "Single-color decompression" begin
+            if decompression == :direct  # TODO: implement for :substitution too
+                A2 = respectful_similar(A)
+                A2 .= zero(eltype(A2))
+                for c in unique(color)
+                    if partition == :column
+                        decompress_single_color!(A2, B[:, c], c, result)
+                    elseif partition == :row
+                        decompress_single_color!(A2, B[c, :], c, result)
+                    end
                 end
+                @test A2 ≈ A0
             end
-            @test A2 ≈ A0
         end
 
-        # Triangle decompression
-        if structure == :symmetric
-            A3upper = respectful_similar(A)
-            A3lower = respectful_similar(A)
-            A3both = respectful_similar(A)
-            A3upper .= zero(eltype(A))
-            A3lower .= zero(eltype(A))
-            A3both .= zero(eltype(A))
+        @testset "Triangle decompression" begin
+            if structure == :symmetric
+                A3upper = respectful_similar(A)
+                A3lower = respectful_similar(A)
+                A3both = respectful_similar(A)
+                A3upper .= zero(eltype(A))
+                A3lower .= zero(eltype(A))
+                A3both .= zero(eltype(A))
 
-            decompress!(A3upper, B, result, :U)
-            decompress!(A3lower, B, result, :L)
-            decompress!(A3both, B, result, :UL)
+                decompress!(A3upper, B, result, :U)
+                decompress!(A3lower, B, result, :L)
+                decompress!(A3both, B, result, :UL)
 
-            @test A3upper ≈ triu(A0)
-            @test A3lower ≈ tril(A0)
-            @test A3both ≈ A0
+                @test A3upper ≈ triu(A0)
+                @test A3lower ≈ tril(A0)
+                @test A3both ≈ A0
+            end
         end
 
-        # Linear system decompression
-        if structure == :symmetric
-            linresult = LinearSystemColoringResult(sparse(A), color, eltype(A))
-            @test decompress(B, linresult) ≈ A0
-            @test decompress!(respectful_similar(A), B, linresult) ≈ A0
+        @testset "Single-color triangle decompression" begin
+            if structure == :symmetric && decompression == :direct
+                A4upper = respectful_similar(A)
+                A4lower = respectful_similar(A)
+                A4both = respectful_similar(A)
+                A4upper .= zero(eltype(A))
+                A4lower .= zero(eltype(A))
+                A4both .= zero(eltype(A))
+
+                for c in unique(color)
+                    decompress_single_color!(A4upper, B[:, c], c, result, :U)
+                    decompress_single_color!(A4lower, B[:, c], c, result, :L)
+                    decompress_single_color!(A4both, B[:, c], c, result, :UL)
+                end
+
+                @test A4upper ≈ triu(A0)
+                @test A4lower ≈ tril(A0)
+                @test A4both ≈ A0
+            end
+        end
+
+        @testset "Linear system decompression" begin
+            if structure == :symmetric
+                linresult = LinearSystemColoringResult(sparse(A), color, eltype(A))
+                @test decompress(B, linresult) ≈ A0
+                @test decompress!(respectful_similar(A), B, linresult) ≈ A0
+            end
         end
     end
 
-    # Coherence between all colorings
-    @test all(color_vec .== Ref(color_vec[1]))
+    @testset "Coherence between all colorings" begin
+        @test all(color_vec .== Ref(color_vec[1]))
+    end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,3 +1,4 @@
+using LinearAlgebra
 using SparseMatrixColorings
 using SparseMatrixColorings: LinearSystemColoringResult, matrix_versions, respectful_similar
 using Test
@@ -10,7 +11,7 @@ function test_coloring_decompression(
     color0=nothing,
 ) where {structure,partition,decompression}
     color_vec = Vector{Int}[]
-    for A in matrix_versions(A0)
+    @testset "$(typeof(A))" for A in matrix_versions(A0)
         result = coloring(A, problem, algo; decompression_eltype=eltype(A))
         color = if partition == :column
             column_colors(result)
@@ -18,14 +19,19 @@ function test_coloring_decompression(
             row_colors(result)
         end
         push!(color_vec, color)
+
         B = compress(A, result)
         !isnothing(color0) && @test color == color0
         !isnothing(B0) && @test B == B0
+
+        # Full decompression
         @test decompress(B, result) ≈ A0
         @test decompress(B, result) ≈ A0  # check result wasn't modified
         @test decompress!(respectful_similar(A), B, result) ≈ A0
         @test decompress!(respectful_similar(A), B, result) ≈ A0
-        if decompression == :direct
+
+        # Colorwise decompression
+        if decompression == :direct  # TODO: implement for :substitution too
             A2 = respectful_similar(A)
             A2 .= zero(eltype(A2))
             for c in unique(color)
@@ -37,11 +43,33 @@ function test_coloring_decompression(
             end
             @test A2 ≈ A0
         end
+
+        # Triangle decompression
+        if structure == :symmetric
+            A3upper = respectful_similar(A)
+            A3lower = respectful_similar(A)
+            A3both = respectful_similar(A)
+            A3upper .= zero(eltype(A))
+            A3lower .= zero(eltype(A))
+            A3both .= zero(eltype(A))
+
+            decompress!(A3upper, B, result, :U)
+            decompress!(A3lower, B, result, :L)
+            decompress!(A3both, B, result, :UL)
+
+            @test A3upper ≈ triu(A0)
+            @test A3lower ≈ tril(A0)
+            @test A3both ≈ A0
+        end
+
+        # Linear system decompression
         if structure == :symmetric
             linresult = LinearSystemColoringResult(sparse(A), color, eltype(A))
             @test decompress(B, linresult) ≈ A0
             @test decompress!(respectful_similar(A), B, linresult) ≈ A0
         end
     end
+
+    # Coherence between all colorings
     @test all(color_vec .== Ref(color_vec[1]))
 end


### PR DESCRIPTION
- [x] Add `uplo = :U/:L/:UL` parameter to `decompress!` and `decompress_single_color!` to allow picking the triangle for symmetric matrices
- [x] Implement the corresponding methods
- [x] Add tests for full decompression and for single color, structure into subtests