### PR TITLE
Bringe coverage to 100%

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -37,7 +37,7 @@ function what_fig_41()
     #! format: on
     @assert M == transpose(M)
     nonzeros(M) .= 1:length(nonzeros(M))
-    A = float.(sparse(Symmetric(M)))
+    A = sparse(Symmetric(M))
     color = [
         1,  # 1. green
         2,  # 2. red
@@ -77,7 +77,7 @@ function what_fig_61()
     #! format: on
     @assert M == transpose(M)
     nonzeros(M) .= 1:length(nonzeros(M))
-    A = float.(sparse(Symmetric(M)))
+    A = sparse(Symmetric(M))
     color = [
         1,  # 1. red
         2,  # 2. blue
@@ -123,7 +123,7 @@ function efficient_fig_1()
     #! format: on
     @assert M == transpose(M)
     nonzeros(M) .= 1:length(nonzeros(M))
-    A = float.(sparse(Symmetric(M)))
+    A = sparse(Symmetric(M))
     color = [
         1,  # 1. red
         2,  # 2. cyan
@@ -171,7 +171,7 @@ function efficient_fig_4()
     #! format: on
     @assert M == transpose(M)
     nonzeros(M) .= 1:length(nonzeros(M))
-    A = float.(sparse(Symmetric(M)))
+    A = sparse(Symmetric(M))
     color = [
         1,  # 1. red
         2,  # 2. cyan

--- a/src/result.jl
+++ b/src/result.jl
@@ -371,7 +371,7 @@ function LinearSystemColoringResult(
         (i < j) && push!(strict_upper_nonzero_inds, (i, j))
     end
 
-    T = spzeros(Float64, n * C, length(strict_upper_nonzero_inds))
+    T = spzeros(float(R), n * C, length(strict_upper_nonzero_inds))
     for (l, (i, j)) in enumerate(strict_upper_nonzero_inds)
         ci = color[i]
         cj = color[j]
@@ -382,7 +382,7 @@ function LinearSystemColoringResult(
     end
     T_factorization = factorize(T)
 
-    strict_upper_nonzeros_A = Vector{R}(undef, size(T, 2))
+    strict_upper_nonzeros_A = Vector{float(R)}(undef, size(T, 2))
 
     return LinearSystemColoringResult(
         S, color, group, strict_upper_nonzero_inds, strict_upper_nonzeros_A, T_factorization

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -12,7 +12,7 @@ function test_coloring_decompression(
 ) where {structure,partition,decompression}
     color_vec = Vector{Int}[]
     @testset "$(typeof(A))" for A in matrix_versions(A0)
-        result = coloring(A, problem, algo; decompression_eltype=eltype(A))
+        result = coloring(A, problem, algo; decompression_eltype=Float64)
         color = if partition == :column
             column_colors(result)
         elseif partition == :row
@@ -91,9 +91,9 @@ function test_coloring_decompression(
 
         @testset "Linear system decompression" begin
             if structure == :symmetric
-                linresult = LinearSystemColoringResult(sparse(A), color, eltype(A))
-                @test decompress(B, linresult) ≈ A0
-                @test decompress!(respectful_similar(A), B, linresult) ≈ A0
+                linresult = LinearSystemColoringResult(sparse(A), color, Float64)
+                @test decompress(float.(B), linresult) ≈ A0
+                @test decompress!(respectful_similar(float.(A)), float.(B), linresult) ≈ A0
             end
         end
     end


### PR DESCRIPTION
- Bring the `eltype` of small examples back to `Int` and set `decompression_eltype=Float64` in `test/utils.jl`, in order to observe a buffer type mismatch.
- Debug `LinearSystemColoringResult` 