### PR TITLE
Add tests with `Symmetric` and `Hermitian` inputs

### DIFF
--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -16,8 +16,11 @@ using DocStringExtensions: README, EXPORTS, SIGNATURES, TYPEDEF, TYPEDFIELDS
 using LinearAlgebra:
     Adjoint,
     Diagonal,
+    Hermitian,
+    LowerTriangular,
     Symmetric,
     Transpose,
+    UpperTriangular,
     adjoint,
     checksquare,
     factorize,


### PR DESCRIPTION
Modify `matrix_versions(A)` so that it also returns `Symmetric` and `Hermitian` versions when appropriate, built from the entire matrix `A` or from either triangle `LowerTriangular(A)` and `UpperTriangular(A)`. This allows testing on more kinds of inputs, including triangles.

#98 was effectively supported (as long as we wrap the triangle into `Symmetric`) but at least it is tested now. We will worry about performance at a later point.