### PR TITLE
Save allocations for bipartite graph with symmetric patterns

### DIFF
--- a/test/graph.jl
+++ b/test/graph.jl
@@ -28,7 +28,8 @@ end;
         0 0 0 1 1 1 1 0
     ])
 
-    bg = bipartite_graph(A)
+    bg = bipartite_graph(A; symmetric_pattern=false)
+    @test_throws DimensionMismatch bipartite_graph(A; symmetric_pattern=true)
     @test length(bg, Val(1)) == 4
     @test length(bg, Val(2)) == 8
     # neighbors of rows
@@ -45,6 +46,21 @@ end;
     @test neighbors(bg, Val(2), 6) == [1, 3, 4]
     @test neighbors(bg, Val(2), 7) == [1, 2, 4]
     @test neighbors(bg, Val(2), 8) == [1, 2, 3]
+
+    A = sparse([
+        1 0 1 1
+        0 1 0 1
+        1 0 1 0
+        1 1 0 1
+    ])
+    bg = bipartite_graph(A; symmetric_pattern=true)
+    @test length(bg, Val(1)) == 4
+    @test length(bg, Val(2)) == 4
+    # neighbors of rows and columns
+    @test neighbors(bg, Val(1), 1) == neighbors(bg, Val(2), 1) == [1, 3, 4]
+    @test neighbors(bg, Val(1), 2) == neighbors(bg, Val(2), 2) == [2, 4]
+    @test neighbors(bg, Val(1), 3) == neighbors(bg, Val(2), 3) == [1, 3]
+    @test neighbors(bg, Val(1), 4) == neighbors(bg, Val(2), 4) == [1, 2, 4]
 end;
 
 ## Adjacency graph (fig 3.1 of "What color is your Jacobian?")

--- a/test/random.jl
+++ b/test/random.jl
@@ -33,6 +33,13 @@ symmetric_params = vcat(
         @test directly_recoverable_columns(A0, color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
+    @testset "$((; n, p))" for (n, p) in symmetric_params
+        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+        color0 = column_coloring(A0, algo)
+        @test structurally_orthogonal_columns(A0, color0)
+        @test directly_recoverable_columns(A0, color0)
+        test_coloring_decompression(A0, problem, algo; color0)
+    end
 end;
 
 @testset "Row coloring & decompression" begin
@@ -40,6 +47,13 @@ end;
     algo = GreedyColoringAlgorithm(; decompression=:direct)
     @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
+        color0 = row_coloring(A0, algo)
+        @test structurally_orthogonal_columns(transpose(A0), color0)
+        @test directly_recoverable_columns(transpose(A0), color0)
+        test_coloring_decompression(A0, problem, algo; color0)
+    end
+    @testset "$((; n, p))" for (n, p) in symmetric_params
+        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         color0 = row_coloring(A0, algo)
         @test structurally_orthogonal_columns(transpose(A0), color0)
         @test directly_recoverable_columns(transpose(A0), color0)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -12,7 +12,15 @@ function test_coloring_decompression(
 ) where {structure,partition,decompression}
     color_vec = Vector{Int}[]
     @testset "$(typeof(A))" for A in matrix_versions(A0)
-        result = coloring(A, problem, algo; decompression_eltype=Float64)
+        yield()
+
+        if structure == :nonsymmetric && issymmetric(A)
+            result = coloring(
+                A, problem, algo; decompression_eltype=Float64, symmetric_pattern=true
+            )
+        else
+            result = coloring(A, problem, algo; decompression_eltype=Float64)
+        end
         color = if partition == :column
             column_colors(result)
         elseif partition == :row


### PR DESCRIPTION
- Add a `symmetric_pattern` kwarg to `coloring`, which can only be used for `:nonsymmetric` coloring problems. I didn't add this to `GreedyColoringAlgorithm` because it is not a property of the algorithm per se.
- Pass this kwarg to `bipartite_graph` and use it to save one allocation for the transpose of the sparse matrix. Even if this kwarg is false, also save the allocation whenever `A isa Union{Symmetric,Hermitian}`
- Add tests of column and row colorings on symmetric matrices.