### PR TITLE
Replace `sparse(A)` with `convert(SparseMatrixCSC, A)`

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -159,7 +159,7 @@ function bipartite_graph(A::SparseMatrixCSC; symmetric_pattern::Bool=false)
         checksquare(A)  # proxy for checking full symmetry
         g1 = g2
     else
-        g1 = Graph{true}(sparse(transpose(A)))  # rows to columns
+        g1 = Graph{true}(convert(SparseMatrixCSC, transpose(A)))  # rows to columns
     end
     return BipartiteGraph(g1, g2)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -180,7 +180,7 @@ function coloring(
     decompression_eltype::Type=Float64,
     symmetric_pattern::Bool=false,
 )
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     bg = bipartite_graph(
         S; symmetric_pattern=symmetric_pattern || A isa Union{Symmetric,Hermitian}
     )
@@ -195,7 +195,7 @@ function coloring(
     decompression_eltype::Type=Float64,
     symmetric_pattern::Bool=false,
 )
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     bg = bipartite_graph(
         S; symmetric_pattern=symmetric_pattern || A isa Union{Symmetric,Hermitian}
     )
@@ -209,7 +209,7 @@ function coloring(
     algo::GreedyColoringAlgorithm{:direct};
     decompression_eltype::Type=Float64,
 )
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     ag = adjacency_graph(S)
     color, star_set = star_coloring(ag, algo.order)
     return StarSetColoringResult(S, color, star_set)
@@ -221,7 +221,7 @@ function coloring(
     algo::GreedyColoringAlgorithm{:substitution};
     decompression_eltype::Type=Float64,
 )
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     ag = adjacency_graph(S)
     color, tree_set = acyclic_coloring(ag, algo.order)
     return TreeSetColoringResult(S, color, tree_set, decompression_eltype)
@@ -230,21 +230,21 @@ end
 ## ADTypes interface
 
 function ADTypes.column_coloring(A::AbstractMatrix, algo::GreedyColoringAlgorithm)
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     bg = bipartite_graph(S; symmetric_pattern=A isa Union{Symmetric,Hermitian})
     color = partial_distance2_coloring(bg, Val(2), algo.order)
     return color
 end
 
 function ADTypes.row_coloring(A::AbstractMatrix, algo::GreedyColoringAlgorithm)
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     bg = bipartite_graph(S; symmetric_pattern=A isa Union{Symmetric,Hermitian})
     color = partial_distance2_coloring(bg, Val(1), algo.order)
     return color
 end
 
 function ADTypes.symmetric_coloring(A::AbstractMatrix, algo::GreedyColoringAlgorithm)
-    S = sparse(A)
+    S = convert(SparseMatrixCSC, A)
     ag = adjacency_graph(S)
     color, star_set = star_coloring(ag, algo.order)
     return color

--- a/src/result.jl
+++ b/src/result.jl
@@ -143,7 +143,7 @@ struct RowColoringResult{M} <: AbstractColoringResult{:nonsymmetric,:row,:direct
 end
 
 function RowColoringResult(S::SparseMatrixCSC, color::Vector{Int})
-    Sᵀ = sparse(transpose(S))
+    Sᵀ = convert(SparseMatrixCSC, transpose(S))
     group = group_by_color(color)
     C = length(group)  # ncolors
     rv = rowvals(S)


### PR DESCRIPTION
When `A` is already a `SparseMatrixCSC`, calling `sparse(A)` makes a useless copy, while `convert(SparseMatrixCSC, A)` doesn't. The behavior in other cases seems identical.