### PR TITLE
Remove dynamic allocations in group_by_color

### DIFF
--- a/src/result.jl
+++ b/src/result.jl
@@ -64,9 +64,16 @@ Assumes the colors are contiguously numbered from `1` to some `cmax`.
 function group_by_color(color::AbstractVector{<:Integer})
     cmin, cmax = extrema(color)
     @assert cmin == 1
-    group = [Int[] for c in 1:cmax]
+    group_sizes = zeros(Int, cmax)
+    for c in color
+        group_sizes[c] += 1
+    end
+    group = [Vector{Int}(undef, group_sizes[c]) for c in 1:cmax]
+    fill!(group_sizes, 1)
     for (k, c) in enumerate(color)
-        push!(group[c], k)
+        pos = group_sizes[c]
+        group[c][pos] = k
+        group_sizes[c] += 1
     end
     return group
 end


### PR DESCRIPTION
@gdalle It seems that we have unexpected allocations in `ColumnResult` and `StarSetResult`.
I will investigate.
