### PR TITLE
Improve graph structure a little bit

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -16,6 +16,7 @@ SparseMatrixColorings.vertices
 SparseMatrixColorings.neighbors
 SparseMatrixColorings.adjacency_graph
 SparseMatrixColorings.bipartite_graph
+transpose
 ```
 
 ## Low-level coloring

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -14,6 +14,7 @@ SparseMatrixColorings.Graph
 SparseMatrixColorings.BipartiteGraph
 SparseMatrixColorings.vertices
 SparseMatrixColorings.neighbors
+SparseMatrixColorings.transpose_graph
 SparseMatrixColorings.adjacency_graph
 SparseMatrixColorings.bipartite_graph
 ```

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -14,7 +14,6 @@ SparseMatrixColorings.Graph
 SparseMatrixColorings.BipartiteGraph
 SparseMatrixColorings.vertices
 SparseMatrixColorings.neighbors
-SparseMatrixColorings.transpose_graph
 SparseMatrixColorings.adjacency_graph
 SparseMatrixColorings.bipartite_graph
 ```

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -35,6 +35,7 @@ using SparseArrays:
     SparseMatrixCSC,
     dropzeros,
     dropzeros!,
+    ftranspose!,
     nnz,
     nonzeros,
     nzrange,

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -19,8 +19,8 @@ The vertices are colored in a greedy fashion, following the `order` supplied.
 function partial_distance2_coloring(
     bg::BipartiteGraph, ::Val{side}, order::AbstractOrder
 ) where {side}
-    color = Vector{Int}(undef, length(bg, Val(side)))
-    forbidden_colors = Vector{Int}(undef, length(bg, Val(side)))
+    color = Vector{Int}(undef, nb_vertices(bg, Val(side)))
+    forbidden_colors = Vector{Int}(undef, nb_vertices(bg, Val(side)))
     vertices_in_order = vertices(bg, Val(side), order)
     partial_distance2_coloring!(color, forbidden_colors, bg, Val(side), vertices_in_order)
     return color
@@ -76,11 +76,11 @@ The vertices are colored in a greedy fashion, following the `order` supplied.
 """
 function star_coloring(g::Graph{false}, order::AbstractOrder)
     # Initialize data structures
-    nvertices = length(g)
-    color = zeros(Int, nvertices)
-    forbidden_colors = zeros(Int, nvertices)
-    first_neighbor = fill((0, 0), nvertices)  # at first no neighbors have been encountered
-    treated = zeros(Int, nvertices)
+    n = nb_vertices(g)
+    color = zeros(Int, n)
+    forbidden_colors = zeros(Int, n)
+    first_neighbor = fill((0, 0), n)  # at first no neighbors have been encountered
+    treated = zeros(Int, n)
     star = Dict{Tuple{Int,Int},Int}()
     hub = Int[]
     vertices_in_order = vertices(g, order)
@@ -269,12 +269,12 @@ The vertices are colored in a greedy fashion, following the `order` supplied.
 """
 function acyclic_coloring(g::Graph{false}, order::AbstractOrder)
     # Initialize data structures
-    nvertices = length(g)
-    nedges = nnz(g) ÷ 2  # symmetric sparse matrix with empty diagonal
-    color = zeros(Int, nvertices)
-    forbidden_colors = zeros(Int, nvertices)
-    first_neighbor = fill((0, 0), nvertices)  # at first no neighbors have been encountered
-    first_visit_to_tree = fill((0, 0), nedges)
+    n = nb_vertices(g)
+    e = nb_edges(g) ÷ 2  # symmetric sparse matrix with empty diagonal
+    color = zeros(Int, n)
+    forbidden_colors = zeros(Int, n)
+    first_neighbor = fill((0, 0), n)  # at first no neighbors have been encountered
+    first_visit_to_tree = fill((0, 0), e)
     forest = DisjointSets{Tuple{Int,Int}}()
     vertices_in_order = vertices(g, order)
 

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -370,6 +370,22 @@ function decompress!(
     return A
 end
 
+function decompress_single_color!(
+    A::SparseMatrixCSC{R}, b::AbstractVector{R}, c::Integer, result::RowColoringResult
+) where {R<:Real}
+    @compat (; S, Sᵀ, group) = result
+    check_same_pattern(A, S)
+    rvSᵀ = rowvals(Sᵀ)
+    nzA = nonzeros(A)
+    for i in group[c]
+        for k in nzrange(Sᵀ, i)
+            j = rvSᵀ[k]
+            nzA[k] = b[j]
+        end
+    end
+    return A
+end
+
 ## StarSetColoringResult
 
 function decompress!(

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -370,22 +370,6 @@ function decompress!(
     return A
 end
 
-function decompress_single_color!(
-    A::SparseMatrixCSC{R}, b::AbstractVector{R}, c::Integer, result::RowColoringResult
-) where {R<:Real}
-    @compat (; S, Sᵀ, group) = result
-    check_same_pattern(A, S)
-    rvSᵀ = rowvals(Sᵀ)
-    nzA = nonzeros(A)
-    for i in group[c]
-        for k in nzrange(Sᵀ, i)
-            j = rvSᵀ[k]
-            nzA[k] = b[j]
-        end
-    end
-    return A
-end
-
 ## StarSetColoringResult
 
 function decompress!(

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -148,7 +148,7 @@ function transpose_graph(A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     A_rowval = A.rowval
 
     # Allocate storage for the column pointers and row indices of B = Aᵀ
-    B_colptr = zeros(Ti, m+1)
+    B_colptr = zeros(Ti, m + 1)
     B_rowval = Vector{Ti}(undef, nnzA)
 
     # Count the number of non-zeros for each row of A.
@@ -165,11 +165,11 @@ function transpose_graph(A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
         B_colptr[col] = counter
         counter += nnz_col
     end
-    B_colptr[m+1] = counter
+    B_colptr[m + 1] = counter
 
     # Store the row indices for each column of B = Aᵀ
     for j in 1:n
-        for index in A_colptr[j]:(A_colptr[j+1] - 1)
+        for index in A_colptr[j]:(A_colptr[j + 1] - 1)
             i = A_rowval[index]
 
             # Update B_rowval for the non-zero B[j,i].
@@ -182,7 +182,7 @@ function transpose_graph(A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
 
     # Fix offsets of B_colptr to restore correct starting positions
     for col in m:-1:2
-        B_colptr[col] = B_colptr[col-1]
+        B_colptr[col] = B_colptr[col - 1]
     end
     B_colptr[1] = 1
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -30,7 +30,6 @@ function Graph{loops}(S::SparseMatrixCSC{Tv,Ti}) where {loops,Tv,Ti}
     return Graph{loops,Ti}(S.m, S.n, S.colptr, S.rowval)
 end
 
-Base.size(g::Graph) = (g.m, g.n)
 SparseArrays.nnz(g::Graph) = length(g.rowval)
 SparseArrays.rowvals(g::Graph) = g.rowval
 SparseArrays.nzrange(g::Graph, j::Integer) = g.colptr[j]:(g.colptr[j + 1] - 1)

--- a/src/order.jl
+++ b/src/order.jl
@@ -41,11 +41,11 @@ end
 RandomOrder() = RandomOrder(default_rng())
 
 function vertices(g::Graph, order::RandomOrder)
-    return randperm(order.rng, length(g))
+    return randperm(order.rng, nb_vertices(g))
 end
 
 function vertices(bg::BipartiteGraph, ::Val{side}, order::RandomOrder) where {side}
-    return randperm(order.rng, length(bg, Val(side)))
+    return randperm(order.rng, nb_vertices(bg, Val(side)))
 end
 
 """

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,6 +1,7 @@
 using LinearAlgebra
 using SparseArrays
-using SparseMatrixColorings: Graph, adjacency_graph, bipartite_graph, degree, neighbors
+using SparseMatrixColorings:
+    Graph, adjacency_graph, bipartite_graph, transpose_graph, degree, neighbors
 using Test
 
 ## Standard graph
@@ -103,4 +104,21 @@ end;
     @test collect(neighbors(g, 6)) == [1, 3, 4, 5, 7, 8]
     @test collect(neighbors(g, 7)) == [1, 2, 4, 5, 6, 8]
     @test collect(neighbors(g, 8)) == [1, 2, 3, 5, 6, 7]
+end
+
+@testset "transpose_graph" begin
+    m = 100
+    n = 50
+    p = 0.02
+    A = sprand(m, n, p)
+    g = transpose_graph(A)
+    B = sparse(transpose(A))
+    @test B.colptr == g.colptr
+    @test B.rowval == g.rowval
+
+    A = sprand(n, m, p)
+    g = transpose_graph(A)
+    B = sparse(transpose(A))
+    @test B.colptr == g.colptr
+    @test B.rowval == g.rowval
 end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,26 +1,40 @@
 using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings:
-    Graph, adjacency_graph, bipartite_graph, transpose_graph, degree, neighbors
+    Graph, adjacency_graph, bipartite_graph, degree, nb_vertices, nb_edges, neighbors
 using Test
 
 ## Standard graph
 
 @testset "Graph" begin
     g = Graph{true}(sparse([
-        1 0 1
-        1 1 0
-        0 0 0
+        1 0 1 1
+        1 1 0 0
+        0 0 0 1
     ]))
+    gᵀ = transpose(g)
 
-    @test length(g) == 3
-    @test nnz(g) == 4
+    @test nb_vertices(g) == 4
+    @test nb_edges(g) == 6
+    @test nnz(g) == 6
     @test neighbors(g, 1) == [1, 2]
     @test neighbors(g, 2) == [2]
     @test neighbors(g, 3) == [1]
+    @test neighbors(g, 4) == [1, 3]
     @test degree(g, 1) == 2
     @test degree(g, 2) == 1
     @test degree(g, 3) == 1
+    @test degree(g, 4) == 2
+
+    @test nb_vertices(gᵀ) == 3
+    @test nb_edges(gᵀ) == 6
+    @test nnz(gᵀ) == 6
+    @test neighbors(gᵀ, 1) == [1, 3, 4]
+    @test neighbors(gᵀ, 2) == [1, 2]
+    @test neighbors(gᵀ, 3) == [4]
+    @test degree(gᵀ, 1) == 3
+    @test degree(gᵀ, 2) == 2
+    @test degree(gᵀ, 3) == 1
 
     g = Graph{false}(sparse([
         1 0 1
@@ -28,8 +42,9 @@ using Test
         0 0 0
     ]))
 
-    @test length(g) == 3
-    @test nnz(g) == 2
+    @test nb_vertices(g) == 3
+    @test nb_edges(g) == 2
+    @test nnz(g) == 4
     @test collect(neighbors(g, 1)) == [2]
     @test collect(neighbors(g, 2)) == Int[]
     @test collect(neighbors(g, 3)) == [1]
@@ -50,8 +65,8 @@ end;
 
     bg = bipartite_graph(A; symmetric_pattern=false)
     @test_throws DimensionMismatch bipartite_graph(A; symmetric_pattern=true)
-    @test length(bg, Val(1)) == 4
-    @test length(bg, Val(2)) == 8
+    @test nb_vertices(bg, Val(1)) == 4
+    @test nb_vertices(bg, Val(2)) == 8
     # neighbors of rows
     @test neighbors(bg, Val(1), 1) == [1, 6, 7, 8]
     @test neighbors(bg, Val(1), 2) == [2, 5, 7, 8]
@@ -74,8 +89,8 @@ end;
         1 1 0 1
     ])
     bg = bipartite_graph(A; symmetric_pattern=true)
-    @test length(bg, Val(1)) == 4
-    @test length(bg, Val(2)) == 4
+    @test nb_vertices(bg, Val(1)) == 4
+    @test nb_vertices(bg, Val(2)) == 4
     # neighbors of rows and columns
     @test neighbors(bg, Val(1), 1) == neighbors(bg, Val(2), 1) == [1, 3, 4]
     @test neighbors(bg, Val(1), 2) == neighbors(bg, Val(2), 2) == [2, 4]
@@ -95,7 +110,7 @@ end;
 
     B = transpose(A) * A
     g = adjacency_graph(B - Diagonal(B))
-    @test length(g) == 8
+    @test nb_vertices(g) == 8
     @test collect(neighbors(g, 1)) == [6, 7, 8]
     @test collect(neighbors(g, 2)) == [5, 7, 8]
     @test collect(neighbors(g, 3)) == [5, 6, 8]
@@ -106,19 +121,13 @@ end;
     @test collect(neighbors(g, 8)) == [1, 2, 3, 5, 6, 7]
 end
 
-@testset "transpose_graph" begin
-    m = 100
-    n = 50
-    p = 0.02
-    A = sprand(m, n, p)
-    g = transpose_graph(A)
-    B = sparse(transpose(A))
-    @test B.colptr == g.colptr
-    @test B.rowval == g.rowval
-
-    A = sprand(n, m, p)
-    g = transpose_graph(A)
-    B = sparse(transpose(A))
-    @test B.colptr == g.colptr
-    @test B.rowval == g.rowval
+@testset "Transpose" begin
+    for _ in 1:1000
+        A = sprand(rand(100:1000), rand(100:1000), 0.1)
+        g = Graph{true}(A)
+        gᵀ = transpose(g)
+        gᵀ_true = Graph{true}(sparse(transpose(A)))
+        @test gᵀ.colptr == gᵀ_true.colptr
+        @test gᵀ.rowval == gᵀ_true.rowval
+    end
 end

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -12,6 +12,8 @@ using SparseMatrixColorings:
     degree,
     minimum_degree,
     maximum_degree,
+    nb_vertices,
+    nb_edges,
     neighbors,
     partial_distance2_coloring,
     star_coloring,
@@ -34,15 +36,16 @@ colpack_table_6_7 = CSV.read(
         original_mat = matrixdepot("$(row[:group])/$(row[:name])")
         mat = dropzeros(original_mat)
         bg = bipartite_graph(mat)
-        @test length(bg, Val(1)) == row[:V1]
-        @test length(bg, Val(2)) == row[:V2]
-        @test nnz(bg) == row[:E]
+        @test nb_vertices(bg, Val(1)) == row[:V1]
+        @test nb_vertices(bg, Val(2)) == row[:V2]
+        @test nb_edges(bg) == row[:E]
         @test maximum_degree(bg, Val(1)) == row[:Δ1]
         @test maximum_degree(bg, Val(2)) == row[:Δ2]
         color_N1 = partial_distance2_coloring(bg, Val(1), NaturalOrder())
         color_N2 = partial_distance2_coloring(bg, Val(2), NaturalOrder())
         @test length(unique(color_N1)) == row[:N1]
         @test length(unique(color_N2)) == row[:N2]
+        yield()
     end
 end;
 
@@ -61,9 +64,9 @@ what_table_31_32 = CSV.read(
         original_mat = matrixdepot("$(row[:group])/$(row[:name])")
         mat = original_mat  # no dropzeros
         bg = bipartite_graph(mat)
-        @test length(bg, Val(1)) == row[:m]
-        @test length(bg, Val(2)) == row[:n]
-        @test nnz(bg) == row[:nnz]
+        @test nb_vertices(bg, Val(1)) == row[:m]
+        @test nb_vertices(bg, Val(2)) == row[:n]
+        @test nb_edges(bg) == row[:nnz]
         @test minimum_degree(bg, Val(1)) == row[:ρmin]
         @test maximum_degree(bg, Val(1)) == row[:ρmax]
         @test minimum_degree(bg, Val(2)) == row[:κmin]
@@ -74,6 +77,7 @@ what_table_31_32 = CSV.read(
         else
             @test_broken length(unique(color_Nb)) == row[:K]
         end
+        yield()
     end
 end;
 
@@ -91,11 +95,12 @@ what_table_41_42 = CSV.read(
         mat = dropzeros(sparse(original_mat))
         ag = adjacency_graph(mat)
         bg = bipartite_graph(mat)
-        @test length(ag) == row[:V]
-        @test nnz(ag) ÷ 2 == row[:E]
+        @test nb_vertices(ag) == row[:V]
+        @test nb_edges(ag) ÷ 2 == row[:E]
         @test maximum_degree(ag) == row[:Δ]
         @test minimum_degree(ag) == row[:δ]
         color_N, _ = star_coloring(ag, NaturalOrder())
         @test_skip row[:KS1] <= length(unique(color_N)) <= row[:KS2]  # TODO: find better
+        yield()
     end
 end;


### PR DESCRIPTION
- Store size information in the `Graph` structure
- Define `nb_vertices` and `nb_edges` in lieu of `length` and `nnz` to avoid confusion
- Redefine `transpose_graph(::AbstractMatrix)` from #107 as `Base.transpose(::Graph)`
- Use a simpler implementation which does just one allocation too many (a new vector of `nzval`), instead of a custom handwritten loop (at least I think so)
- Add better transposition tests