### PR TITLE
Consider distance-2 degree for `LargestFirst` order in bipartite graph

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -182,6 +182,18 @@ function minimum_degree(bg::BipartiteGraph, ::Val{side}) where {side}
     return minimum(v -> degree(bg, Val(side), v), vertices(bg, Val(side)))
 end
 
+function degree_dist2(bg::BipartiteGraph{T}, ::Val{side}, v::Integer) where {T,side}
+    # not efficient, for testing purposes only
+    other_side = 3 - side
+    neighbors_dist2 = Set{T}()
+    for u in neighbors(bg, Val(side), v)
+        for w in neighbors(bg, Val(other_side), u)
+            w != v && push!(neighbors_dist2, w)
+        end
+    end
+    return length(neighbors_dist2)
+end
+
 ## Construct from matrices
 
 """

--- a/src/order.jl
+++ b/src/order.jl
@@ -61,6 +61,21 @@ function vertices(g::Graph, ::LargestFirst)
 end
 
 function vertices(bg::BipartiteGraph, ::Val{side}, ::LargestFirst) where {side}
-    criterion(v) = degree(bg, Val(side), v)
+    other_side = 3 - side
+    n = nb_vertices(bg, Val(side))
+    visited = falses(n)  # necessary for distance-2 neighborhoods
+    degrees_dist2 = zeros(Int, n)
+    for v in vertices(bg, Val(side))
+        fill!(visited, false)
+        for u in neighbors(bg, Val(side), v)
+            for w in neighbors(bg, Val(other_side), u)
+                if w != v && !visited[w]
+                    degrees_dist2[v] += 1
+                    visited[w] = true  # avoid double counting
+                end
+            end
+        end
+    end
+    criterion(v) = degrees_dist2[v]
     return sort(vertices(bg, Val(side)); by=criterion, rev=true)
 end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -1,7 +1,14 @@
 using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings:
-    Graph, adjacency_graph, bipartite_graph, degree, nb_vertices, nb_edges, neighbors
+    Graph,
+    adjacency_graph,
+    bipartite_graph,
+    degree,
+    degree_dist2,
+    nb_vertices,
+    nb_edges,
+    neighbors
 using Test
 
 ## Standard graph
@@ -81,6 +88,14 @@ end;
     @test neighbors(bg, Val(2), 6) == [1, 3, 4]
     @test neighbors(bg, Val(2), 7) == [1, 2, 4]
     @test neighbors(bg, Val(2), 8) == [1, 2, 3]
+    @test degree_dist2(bg, Val(2), 1) == 3
+    @test degree_dist2(bg, Val(2), 2) == 3
+    @test degree_dist2(bg, Val(2), 3) == 3
+    @test degree_dist2(bg, Val(2), 4) == 3
+    @test degree_dist2(bg, Val(2), 5) == 6
+    @test degree_dist2(bg, Val(2), 6) == 6
+    @test degree_dist2(bg, Val(2), 7) == 6
+    @test degree_dist2(bg, Val(2), 8) == 6
 
     A = sparse([
         1 0 1 1

--- a/test/order.jl
+++ b/test/order.jl
@@ -1,11 +1,13 @@
 using SparseArrays
 using SparseMatrixColorings:
+    BipartiteGraph,
     Graph,
     adjacency_graph,
     bipartite_graph,
     LargestFirst,
     NaturalOrder,
     RandomOrder,
+    degree_dist2,
     vertices
 using StableRNGs
 using Test
@@ -54,21 +56,18 @@ end;
     @test vertices(ag, LargestFirst()) == [2, 1, 3]
 
     A = sparse([
-        1 1 1
-        1 0 0
-        0 1 1
-        0 0 0
-    ])
-    bg = bipartite_graph(A)
-
-    @test vertices(bg, Val(1), LargestFirst()) == [1, 3, 2, 4]
-
-    A = sparse([
         1 1 0 0
-        1 0 1 0
+        0 1 1 1
+        0 0 1 0
+        0 0 0 0
         1 0 1 0
     ])
     bg = bipartite_graph(A)
 
-    @test vertices(bg, Val(2), LargestFirst()) == [1, 3, 2, 4]
+    for side in (1, 2)
+        true_order = sort(
+            vertices(bg, Val(side)); by=v -> degree_dist2(bg, Val(side), v), rev=true
+        )
+        @test vertices(bg, Val(side), LargestFirst()) == true_order
+    end
 end;


### PR DESCRIPTION
Start fixing #118 by correcting the `LargestFirst` order to take distance-2 degree into account.
Add some tests (we probably need more).