### PR TITLE
Implement `ConstantColoringAlgorithm`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -17,6 +17,7 @@ SparseMatrixColorings
 coloring
 ColoringProblem
 GreedyColoringAlgorithm
+ConstantColoringAlgorithm
 ```
 
 ## Result analysis

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -49,12 +49,14 @@ include("coloring.jl")
 include("result.jl")
 include("matrices.jl")
 include("interface.jl")
+include("constant.jl")
 include("decompression.jl")
 include("check.jl")
 include("examples.jl")
 
 export NaturalOrder, RandomOrder, LargestFirst
 export ColoringProblem, GreedyColoringAlgorithm, AbstractColoringResult
+export ConstantColoringAlgorithm
 export coloring
 export column_colors, row_colors
 export column_groups, row_groups

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -1,0 +1,73 @@
+"""
+    ConstantColoringAlgorithm{partition}  <: ADTypes.AbstractColoringAlgorithm
+
+Coloring algorithm which always returns the same precomputed vector of colors.
+Useful when the optimal coloring of a matrix can be determined a priori due to its specific structure (e.g. banded).
+
+It is passed as an argument to the main function [`coloring`](@ref), but will only work if the associated `problem` has `:nonsymmetric` structure.
+Indeed, for symmetric coloring problems, we need more than just the vector of colors to allow fast decompression.
+
+# Constructors
+
+    ConstantColoringAlgorithm{partition}(matrix_template, color)
+    ConstantColoringAlgorithm(matrix_template, color; partition=:column)
+
+- `partition::Symbol`: either `:row` or `:column`.
+- `matrix_template::AbstractMatrix`: matrix for which the vector of colors was precomputed (the algorithm will only accept matrices of the exact same size).
+- `color::Vector{Int}`: vector of integer colors, one for each row or column (depending on `partition`).
+
+!!! warning
+    The second constructor (based on keyword arguments) is type-unstable.
+
+We do not necessarily verify consistency between the matrix template and the vector of colors, this is the responsibility of the user.
+"""
+struct ConstantColoringAlgorithm{
+    partition,M<:AbstractMatrix,R<:AbstractColoringResult{:nonsymmetric,partition,:direct}
+} <: ADTypes.AbstractColoringAlgorithm
+    matrix_template::M
+    color::Vector{Int}
+    result::R
+end
+
+function ConstantColoringAlgorithm{:column}(
+    matrix_template::AbstractMatrix, color::Vector{Int}
+)
+    S = convert(SparseMatrixCSC, matrix_template)
+    result = ColumnColoringResult(S, color)
+    M, R = typeof(matrix_template), typeof(result)
+    return ConstantColoringAlgorithm{:column,M,R}(matrix_template, color, result)
+end
+
+function ConstantColoringAlgorithm{:row}(
+    matrix_template::AbstractMatrix, color::Vector{Int}
+)
+    S = convert(SparseMatrixCSC, matrix_template)
+    result = RowColoringResult(S, color)
+    M, R = typeof(matrix_template), typeof(result)
+    return ConstantColoringAlgorithm{:row,M,R}(matrix_template, color, result)
+end
+
+function ConstantColoringAlgorithm(
+    matrix_template::AbstractMatrix, color::Vector{Int}; partition=:column
+)
+    return ConstantColoringAlgorithm{partition}(matrix_template, color)
+end
+
+function coloring(
+    A::AbstractMatrix,
+    ::ColoringProblem{:nonsymmetric,partition},
+    algo::ConstantColoringAlgorithm{partition};
+    decompression_eltype::Type=Float64,
+    symmetric_pattern::Bool=false,
+) where {partition}
+    @compat (; matrix_template, result) = algo
+    if size(A) != size(matrix_template)
+        throw(
+            DimensionMismatch(
+                "`ConstantColoringAlgorithm` expected matrix of size $(size(matrix_template)) but got matrix of size $(size(A))",
+            ),
+        )
+    else
+        return result
+    end
+end

--- a/test/constant.jl
+++ b/test/constant.jl
@@ -1,3 +1,4 @@
+using ADTypes: ADTypes
 using SparseMatrixColorings
 using Test
 
@@ -12,6 +13,8 @@ matrix_template = ones(100, 200)
     @test_throws MethodError coloring(matrix_template, problem, wrong_algo)
     result = coloring(matrix_template, problem, algo)
     @test column_colors(result) == color
+    @test ADTypes.column_coloring(matrix_template, algo) == color
+    @test_throws MethodError ADTypes.row_coloring(matrix_template, algo)
 end
 
 @testset "Row coloring" begin
@@ -21,6 +24,8 @@ end
     @test_throws DimensionMismatch coloring(transpose(matrix_template), problem, algo)
     result = coloring(matrix_template, problem, algo)
     @test row_colors(result) == color
+    @test ADTypes.row_coloring(matrix_template, algo) == color
+    @test_throws MethodError ADTypes.column_coloring(matrix_template, algo)
 end
 
 @testset "Symmetric coloring" begin
@@ -28,4 +33,5 @@ end
     color = rand(1:5, size(matrix_template, 2))
     algo = ConstantColoringAlgorithm(matrix_template, color; partition=:column)
     @test_throws MethodError coloring(matrix_template, wrong_problem, algo)
+    @test_throws MethodError ADTypes.symmetric_coloring(matrix_template, algo)
 end

--- a/test/constant.jl
+++ b/test/constant.jl
@@ -1,0 +1,31 @@
+using SparseMatrixColorings
+using Test
+
+matrix_template = ones(100, 200)
+
+@testset "Column coloring" begin
+    problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
+    color = rand(1:5, size(matrix_template, 2))
+    algo = ConstantColoringAlgorithm(matrix_template, color; partition=:column)
+    wrong_algo = ConstantColoringAlgorithm(matrix_template, color; partition=:row)
+    @test_throws DimensionMismatch coloring(transpose(matrix_template), problem, algo)
+    @test_throws MethodError coloring(matrix_template, problem, wrong_algo)
+    result = coloring(matrix_template, problem, algo)
+    @test column_colors(result) == color
+end
+
+@testset "Row coloring" begin
+    problem = ColoringProblem(; structure=:nonsymmetric, partition=:row)
+    color = rand(1:5, size(matrix_template, 1))
+    algo = ConstantColoringAlgorithm(matrix_template, color; partition=:row)
+    @test_throws DimensionMismatch coloring(transpose(matrix_template), problem, algo)
+    result = coloring(matrix_template, problem, algo)
+    @test row_colors(result) == color
+end
+
+@testset "Symmetric coloring" begin
+    wrong_problem = ColoringProblem(; structure=:symmetric, partition=:column)
+    color = rand(1:5, size(matrix_template, 2))
+    algo = ConstantColoringAlgorithm(matrix_template, color; partition=:column)
+    @test_throws MethodError coloring(matrix_template, wrong_problem, algo)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,9 @@ include("utils.jl")
         @testset "Constructors" begin
             include("constructors.jl")
         end
+        @testset "Constant coloring" begin
+            include("constant.jl")
+        end
     end
     @testset verbose = true "Correctness" begin
         @testset "Small instances" begin


### PR DESCRIPTION
- Add a new `ConstantColoringAlgorithm` which always returns the same `ColumnColoringResult` or `RowColoringResult` (fix #124)
- Make sure it errors when it is used inappropriately (wrong type of coloring, wrong matrix shape)
- Document and test it properly