### PR TITLE
Decompression of acyclic coloring with SparseMatrixCSC

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -519,6 +519,7 @@ function decompress!(
         upper_triangle_offsets,
         buffer,
     ) = result
+    A_colptr = A.colptr
     nzA = nonzeros(A)
     uplo == :F && check_same_pattern(A, S)
 
@@ -532,13 +533,13 @@ function decompress!(
     if uplo == :L
         for i in diagonal_indices
             # A[i, i] is the first element in column i
-            nzind = A.colptr[i]
+            nzind = A_colptr[i]
             nzA[nzind] = B[i, color[i]]
         end
     elseif uplo == :U
         for i in diagonal_indices
             # A[i, i] is the last element in column i
-            nzind = A.colptr[i + 1] - 1
+            nzind = A_colptr[i + 1] - 1
             nzA[nzind] = B[i, color[i]]
         end
     else  # uplo == :F
@@ -568,14 +569,14 @@ function decompress!(
                 # uplo = :L or uplo = :F
                 # A[i,j] is stored at index_ij = (A.colptr[j+1] - offset_L) in A.nzval
                 if uplo != :U
-                    nzind = A.colptr[j + 1] - lower_triangle_offsets[counter]
+                    nzind = A_colptr[j + 1] - lower_triangle_offsets[counter]
                     nzA[nzind] = val
                 end
 
                 # uplo = :U or uplo = :F
                 # A[j,i] is stored at index_ji = (A.colptr[i] + offset_U) in A.nzval
                 if uplo != :L
-                    nzind = A.colptr[i] + upper_triangle_offsets[counter]
+                    nzind = A_colptr[i] + upper_triangle_offsets[counter]
                     nzA[nzind] = val
                 end
 
@@ -584,14 +585,14 @@ function decompress!(
                 # uplo = :U or uplo = :F
                 # A[i,j] is stored at index_ij = (A.colptr[j] + offset_U) in A.nzval
                 if uplo != :L
-                    nzind = A.colptr[j] + upper_triangle_offsets[counter]
+                    nzind = A_colptr[j] + upper_triangle_offsets[counter]
                     nzA[nzind] = val
                 end
 
                 # uplo = :L or uplo = :F
                 # A[j,i] is stored at index_ji = (A.colptr[i+1] - offset_L) in A.nzval
                 if uplo != :U
-                    nzind = A.colptr[i + 1] - lower_triangle_offsets[counter]
+                    nzind = A_colptr[i + 1] - lower_triangle_offsets[counter]
                     nzA[nzind] = val
                 end
             end

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -562,27 +562,40 @@ function decompress!(
             val = B[i, color[j]] - buffer_right_type[i]
             buffer_right_type[j] = buffer_right_type[j] + val
 
-            # A[i,j] = val
-            if in_triangle(i, j, uplo)
-                if uplo == :L
+            #! format: off
+            # A[i,j] is in the lower triangular part of A
+            if in_triangle(i, j, :L)
+                # uplo = :L or uplo = :F
+                # A[i,j] is stored at index_ij = (A.colptr[j+1] - offset_L) in A.nzval
+                if uplo != :U
                     nzind = A.colptr[j + 1] - lower_triangle_offsets[counter]
-                else
-                    nzind = A.colptr[j] + upper_triangle_offsets[counter]
+                    nzA[nzind] = val
                 end
-                # Both values of `nzind` can be used if uplo = :F
-                nzA[nzind] = val
-            end
 
-            # A[j,i] = val
-            if in_triangle(j, i, uplo)
-                if uplo == :L
-                    nzind = A.colptr[i + 1] - lower_triangle_offsets[counter]
-                else
+                # uplo = :U or uplo = :F
+                # A[j,i] is stored at index_ji = (A.colptr[i] + offset_U) in A.nzval
+                if uplo != :L
                     nzind = A.colptr[i] + upper_triangle_offsets[counter]
+                    nzA[nzind] = val
                 end
-                # Both values of `nzind` can be used if uplo = :F
-                nzA[nzind] = val
+
+            # A[i,j] is in the upper triangular part of A
+            else
+                # uplo = :U or uplo = :F
+                # A[i,j] is stored at index_ij = (A.colptr[j] + offset_U) in A.nzval
+                if uplo != :L
+                    nzind = A.colptr[j] + upper_triangle_offsets[counter]
+                    nzA[nzind] = val
+                end
+
+                # uplo = :L or uplo = :F
+                # A[j,i] is stored at index_ji = (A.colptr[i+1] - offset_L) in A.nzval
+                if uplo != :U
+                    nzind = A.colptr[i + 1] - lower_triangle_offsets[counter]
+                    nzA[nzind] = val
+                end
             end
+            #! format: on
         end
     end
     return A

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -509,7 +509,6 @@ function decompress!(
     uplo::Symbol=:F,
 ) where {R<:Real}
     @compat (;
-        S,
         color,
         vertices_by_tree,
         reverse_bfs_orders,
@@ -519,6 +518,7 @@ function decompress!(
         upper_triangle_offsets,
         buffer,
     ) = result
+    S = result.ag.S
     A_colptr = A.colptr
     nzA = nonzeros(A)
     uplo == :F && check_same_pattern(A, S)

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -508,7 +508,7 @@ function decompress!(
     result::TreeSetColoringResult,
     uplo::Symbol=:F,
 ) where {R<:Real}
-    @compat (;
+    (;
         color,
         vertices_by_tree,
         reverse_bfs_orders,


### PR DESCRIPTION
close #93

- Add the following method:
```julia
decompress!(A::SparseMatrixCSC{R}, B::AbstractMatrix{R}, result::TreeSetColoringResult, uplo::Symbol=:F)
   ...
end
```