### PR TITLE
Add `sparsity_pattern` getter for results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle", "Alexis Montoison"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,6 +28,7 @@ column_colors
 row_colors
 column_groups
 row_groups
+sparsity_pattern
 ```
 
 ## Decompression

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -60,6 +60,7 @@ export ConstantColoringAlgorithm
 export coloring
 export column_colors, row_colors
 export column_groups, row_groups
+export sparsity_pattern
 export compress, decompress, decompress!, decompress_single_color!
 
 end

--- a/src/result.jl
+++ b/src/result.jl
@@ -19,6 +19,7 @@ Combination between the type parameters of [`ColoringProblem`](@ref) and [`Greed
 
 - [`column_colors`](@ref) and [`column_groups`](@ref) (for a `:column` or `:bidirectional` partition) 
 - [`row_colors`](@ref) and [`row_groups`](@ref) (for a `:row` or `:bidirectional` partition)
+- [`sparsity_pattern`](@ref)
 - [`compress`](@ref), [`decompress`](@ref), [`decompress!`](@ref), [`decompress_single_color!`](@ref)
 
 !!! warning
@@ -83,6 +84,16 @@ column_groups(result::AbstractColoringResult{s,:column}) where {s} = result.grou
 
 row_colors(result::AbstractColoringResult{s,:row}) where {s} = result.color
 row_groups(result::AbstractColoringResult{s,:row}) where {s} = result.group
+
+"""
+    sparsity_pattern(result::AbstractColoringResult)
+
+Return the matrix that was initially passed to [`coloring`](@ref), without any modifications.
+
+!!! note
+    This matrix is not necessarily a `SparseMatrixCSC`, nor does it necessarily have `Bool` entries.
+"""
+sparsity_pattern(result::AbstractColoringResult) = result.A
 
 ## Concrete subtypes
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -2,10 +2,6 @@ using ADTypes: column_coloring, row_coloring, symmetric_coloring
 using LinearAlgebra
 using SparseArrays
 using SparseMatrixColorings
-using SparseMatrixColorings:
-    structurally_orthogonal_columns,
-    symmetrically_orthogonal_columns,
-    directly_recoverable_columns
 using StableRNGs
 using Test
 
@@ -29,15 +25,11 @@ symmetric_params = vcat(
     @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         color0 = column_coloring(A0, algo)
-        @test structurally_orthogonal_columns(A0, color0)
-        @test directly_recoverable_columns(A0, color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
     @testset "$((; n, p))" for (n, p) in symmetric_params
         A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         color0 = column_coloring(A0, algo)
-        @test structurally_orthogonal_columns(A0, color0)
-        @test directly_recoverable_columns(A0, color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
 end;
@@ -48,15 +40,11 @@ end;
     @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         color0 = row_coloring(A0, algo)
-        @test structurally_orthogonal_columns(transpose(A0), color0)
-        @test directly_recoverable_columns(transpose(A0), color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
     @testset "$((; n, p))" for (n, p) in symmetric_params
         A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         color0 = row_coloring(A0, algo)
-        @test structurally_orthogonal_columns(transpose(A0), color0)
-        @test directly_recoverable_columns(transpose(A0), color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
 end;
@@ -67,8 +55,6 @@ end;
     @testset "$((; n, p))" for (n, p) in symmetric_params
         A0 = sparse(Symmetric(sprand(rng, n, n, p)))
         color0 = symmetric_coloring(A0, algo)
-        @test symmetrically_orthogonal_columns(A0, color0)
-        @test directly_recoverable_columns(A0, color0)
         test_coloring_decompression(A0, problem, algo; color0)
     end
 end;

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -31,7 +31,6 @@ colpack_table_6_7 = CSV.read(
 
 @testset "Distance-2 coloring (ColPack paper)" begin
     @testset "$(row[:name])" for row in eachrow(colpack_table_6_7)
-        @info "Testing distance-2 coloring for $(row[:name]) against ColPack paper"
         original_mat = matrixdepot("$(row[:group])/$(row[:name])")
         mat = dropzeros(original_mat)
         bg = BipartiteGraph(mat)
@@ -59,7 +58,6 @@ what_table_31_32 = CSV.read(
 @testset "Distance-2 coloring (survey paper)" begin
     @testset "$(row[:name])" for row in eachrow(what_table_31_32)
         ismissing(row[:group]) && continue
-        @info "Testing distance-2 coloring for $(row[:name]) against survey paper"
         original_mat = matrixdepot("$(row[:group])/$(row[:name])")
         mat = original_mat  # no dropzeros
         bg = BipartiteGraph(mat)
@@ -89,7 +87,6 @@ what_table_41_42 = CSV.read(
 @testset "Star coloring (survey paper)" begin
     @testset "$(row[:name])" for row in eachrow(what_table_41_42)
         ismissing(row[:group]) && continue
-        @info "Testing star coloring for $(row[:name]) against survey paper"
         original_mat = matrixdepot("$(row[:group])/$(row[:name])")
         mat = dropzeros(sparse(original_mat))
         ag = AdjacencyGraph(mat)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,13 @@
 using LinearAlgebra
 using SparseMatrixColorings
 using SparseMatrixColorings:
-    AdjacencyGraph, LinearSystemColoringResult, matrix_versions, respectful_similar
+    AdjacencyGraph,
+    LinearSystemColoringResult,
+    directly_recoverable_columns,
+    matrix_versions,
+    respectful_similar,
+    structurally_orthogonal_columns,
+    symmetrically_orthogonal_columns
 using Test
 
 function test_coloring_decompression(
@@ -32,8 +38,27 @@ function test_coloring_decompression(
         B = compress(A, result)
 
         @testset "Reference" begin
+            @test sparsity_pattern(result) === A  # identity of objects
             !isnothing(color0) && @test color == color0
             !isnothing(B0) && @test B == B0
+        end
+
+        @testset "Recoverability" begin
+            # TODO: find tests for recoverability for substitution decompression
+            if decompression == :direct
+                if structure == :nonsymmetric
+                    if partition == :column
+                        @test structurally_orthogonal_columns(A0, color)
+                        @test directly_recoverable_columns(A0, color)
+                    else
+                        @test structurally_orthogonal_columns(transpose(A0), color)
+                        @test directly_recoverable_columns(transpose(A0), color)
+                    end
+                else
+                    @test symmetrically_orthogonal_columns(A0, color)
+                    @test directly_recoverable_columns(A0, color)
+                end
+            end
         end
 
         @testset "Full decompression" begin
@@ -102,6 +127,7 @@ function test_coloring_decompression(
             if structure == :symmetric && count(!iszero, A) > 0  # sparse factorization cannot handle empty matrices
                 ag = AdjacencyGraph(A)
                 linresult = LinearSystemColoringResult(A, ag, color, Float64)
+                @test sparsity_pattern(result) === A  # identity of objects
                 @test decompress(float.(B), linresult) ≈ A0
                 @test decompress!(respectful_similar(float.(A)), float.(B), linresult) ≈ A0
             end


### PR DESCRIPTION
- Bump version to v0.4.4
- Implement a function `sparsity_pattern` which returns exactly the matrix `A` that was given to the coloring algorithm. That way, @Vaibhavdixit02 and others won't have to rely on internals to retrieve it.
- Add this new function to `test/utils.jl` and move some code around there 

> [!NOTE]
> Until the next breaking version, this effectively imposes that the sparsity pattern should always be stored in the result type (which is true since #126)