### PR TITLE
Improve type stability in star set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle", "Alexis Montoison"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -240,7 +240,7 @@ function symmetric_coefficient(
     if h == j
         # i is the spoke
         return i, color[h]
-    elseif h == i
+    else
         # j is the spoke
         return j, color[h]
     end


### PR DESCRIPTION
Make sure that there is no branch where `symmetric_coefficient` returns `nothing`.

This caused JET's type stability tests to fail on the pre-release version of Julia in https://github.com/gdalle/DifferentiationInterface.jl/pull/535