### PR TITLE
Working prototype for bicoloring (coloring + decompression)

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -40,6 +40,7 @@ SparseMatrixColorings.RowColoringResult
 SparseMatrixColorings.StarSetColoringResult
 SparseMatrixColorings.TreeSetColoringResult
 SparseMatrixColorings.LinearSystemColoringResult
+SparseMatrixColorings.BicoloringResult
 ```
 
 ## Testing

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -571,10 +571,10 @@ function decompress!(
     B = zeros(T, n + m, length(unique(symmetric_color)))
     for c in axes(B, 2)
         if haskey(col_color_ind, c)  # some columns were colored with c
-            B[:, c] .+= vcat(zeros(T, n), Bc[:, col_color_ind[c]])
+            B[(n + 1):(n + m), c] .+= @view Bc[:, col_color_ind[c]]
         end
         if haskey(row_color_ind, c)  # some rows were colored with c
-            B[:, c] .+= vcat(Br[row_color_ind[c], :], zeros(T, m))
+            B[1:n, c] .+= @view Br[row_color_ind[c], :]
         end
     end
     new_A = decompress(B, result.symmetric_result)

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -134,7 +134,6 @@ end
 
 function decompress(Br::AbstractMatrix, Bc::AbstractMatrix, result::AbstractColoringResult)
     A = respectful_similar(result.A, Base.promote_eltype(Br, Bc))
-    fill!(A, zero(eltype(A)))
     return decompress!(A, Br, Bc, result)
 end
 

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -9,9 +9,6 @@ Compress `A` given a coloring `result` of the sparsity pattern of `A`.
 Compression means summing either the columns or the rows of `A` which share the same color.
 It is undone by calling [`decompress`](@ref) or [`decompress!`](@ref).
 
-!!! warning
-    At the moment, `:bidirectional` partitions are not implemented.
-
 # Example
 
 ```jldoctest
@@ -63,8 +60,23 @@ function compress(A, result::AbstractColoringResult{structure,:row}) where {stru
     return B
 end
 
+function compress(
+    A, result::AbstractColoringResult{structure,:bidirectional}
+) where {structure}
+    row_group = row_groups(result)
+    column_group = column_groups(result)
+    Br = stack(row_group; dims=1) do g
+        dropdims(sum(A[g, :]; dims=1); dims=1)
+    end
+    Bc = stack(column_group; dims=2) do g
+        dropdims(sum(A[:, g]; dims=2); dims=2)
+    end
+    return Br, Bc
+end
+
 """
     decompress(B::AbstractMatrix, result::AbstractColoringResult)
+    decompress(Br::AbstractMatrix, Bc::AbstractMatrix, result::AbstractColoringResult)
 
 Decompress `B` into a new matrix `A`, given a coloring `result` of the sparsity pattern of `A`.
 The in-place alternative is [`decompress!`](@ref).
@@ -120,9 +132,20 @@ function decompress(B::AbstractMatrix, result::AbstractColoringResult)
     return decompress!(A, B, result)
 end
 
+function decompress(Br::AbstractMatrix, Bc::AbstractMatrix, result::AbstractColoringResult)
+    A = respectful_similar(result.A, Base.promote_eltype(Br, Bc))
+    fill!(A, zero(eltype(A)))
+    return decompress!(A, Br, Bc, result)
+end
+
 """
     decompress!(
         A::AbstractMatrix, B::AbstractMatrix,
+        result::AbstractColoringResult, [uplo=:F]
+    )
+
+    decompress!(
+        A::AbstractMatrix, Br::AbstractMatrix, Bc::AbstractMatrix
         result::AbstractColoringResult, [uplo=:F]
     )
 
@@ -407,7 +430,7 @@ function decompress_single_color!(
 )
     @compat (; color, group, star_set) = result
     @compat (; hub, spokes) = star_set
-    S = result.ag.S
+    S = pattern(result.ag)
     uplo == :F && check_same_pattern(A, S)
     for i in axes(A, 1)
         if !iszero(S[i, i]) && color[i] == c
@@ -434,7 +457,7 @@ function decompress!(
     A::SparseMatrixCSC, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
     @compat (; compressed_indices) = result
-    S = result.ag.S
+    S = pattern(result.ag)
     nzA = nonzeros(A)
     if uplo == :F
         check_same_pattern(A, S)
@@ -466,7 +489,7 @@ function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::TreeSetColoringResult, uplo::Symbol=:F
 )
     @compat (; color, vertices_by_tree, reverse_bfs_orders, buffer) = result
-    S = result.ag.S
+    S = pattern(result.ag)
     uplo == :F && check_same_pattern(A, S)
     R = eltype(A)
     fill!(A, zero(R))
@@ -514,7 +537,7 @@ function decompress!(
 )
     @compat (; color, strict_upper_nonzero_inds, T_factorization, strict_upper_nonzeros_A) =
         result
-    S = result.ag.S
+    S = pattern(result.ag)
     uplo == :F && check_same_pattern(A, S)
 
     # TODO: for some reason I cannot use ldiv! with a sparse QR
@@ -534,4 +557,27 @@ function decompress!(
         end
     end
     return A
+end
+
+## BicoloringResult
+
+function decompress!(
+    A::AbstractMatrix, Br::AbstractMatrix, Bc::AbstractMatrix, result::BicoloringResult
+)
+    m, n = size(A)
+    T = Base.promote_eltype(Br, Bc)
+    symmetric_color = column_colors(result.symmetric_result)
+    _, col_color_ind = remap_colors(symmetric_color[1:n])
+    _, row_color_ind = remap_colors(symmetric_color[(n + 1):(n + m)])
+    B = zeros(T, n + m, length(unique(symmetric_color)))
+    for c in axes(B, 2)
+        if haskey(col_color_ind, c)  # some columns were colored with c
+            B[:, c] .+= vcat(zeros(T, n), Bc[:, col_color_ind[c]])
+        end
+        if haskey(row_color_ind, c)  # some rows were colored with c
+            B[:, c] .+= vcat(Br[row_color_ind[c], :], zeros(T, m))
+        end
+    end
+    new_A = decompress(B, result.symmetric_result)
+    return copyto!(A, new_A[(n + 1):(n + m), 1:n])
 end

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -568,7 +568,7 @@ function decompress!(
     symmetric_color = column_colors(result.symmetric_result)
     _, col_color_ind = remap_colors(symmetric_color[1:n])
     _, row_color_ind = remap_colors(symmetric_color[(n + 1):(n + m)])
-    B = zeros(T, n + m, length(unique(symmetric_color)))
+    B = zeros(T, n + m, maximum(symmetric_color))
     for c in axes(B, 2)
         if haskey(col_color_ind, c)  # some columns were colored with c
             B[(n + 1):(n + m), c] .+= @view Bc[:, col_color_ind[c]]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -226,41 +226,27 @@ end
 function coloring(
     A::AbstractMatrix,
     ::ColoringProblem{:nonsymmetric,:bidirectional},
-    algo::GreedyColoringAlgorithm{:direct};
+    algo::GreedyColoringAlgorithm{decompression};
     decompression_eltype::Type=Float64,
     symmetric_pattern::Bool=false,
-)
+) where {decompression}
     m, n = size(A)
     abg = AdjacencyFromBipartiteGraph(
         A; symmetric_pattern=symmetric_pattern || A isa Union{Symmetric,Hermitian}
     )
-    bigA = SparseMatrixCSC(pattern(abg))
-    color, star_set = star_coloring(abg, algo.order)
-    star_set_result = StarSetColoringResult(bigA, abg, color, star_set)
+    bigA = SparseMatrixCSC(pattern(abg))  # TODO: slow
+    if decompression == :direct
+        color, star_set = star_coloring(abg, algo.order)
+        symmetric_result = StarSetColoringResult(bigA, abg, color, star_set)
+    else
+        color, tree_set = acyclic_coloring(abg, algo.order)
+        symmetric_result = TreeSetColoringResult(
+            bigA, abg, color, tree_set, decompression_eltype
+        )
+    end
     column_color, _ = remap_colors(color[1:n])
     row_color, _ = remap_colors(color[(n + 1):(n + m)])
-    return BicoloringResult(A, abg, column_color, row_color, star_set_result)
-end
-
-function coloring(
-    A::AbstractMatrix,
-    ::ColoringProblem{:nonsymmetric,:bidirectional},
-    algo::GreedyColoringAlgorithm{:substitution};
-    decompression_eltype::Type=Float64,
-    symmetric_pattern::Bool=false,
-)
-    m, n = size(A)
-    abg = AdjacencyFromBipartiteGraph(
-        A; symmetric_pattern=symmetric_pattern || A isa Union{Symmetric,Hermitian}
-    )
-    bigA = SparseMatrixCSC(pattern(abg))
-    color, tree_set = acyclic_coloring(abg, algo.order)
-    tree_set_result = TreeSetColoringResult(
-        bigA, abg, color, tree_set, decompression_eltype
-    )
-    column_color, _ = remap_colors(color[1:n])
-    row_color, _ = remap_colors(color[(n + 1):(n + m)])
-    return BicoloringResult(A, abg, column_color, row_color, tree_set_result)
+    return BicoloringResult(A, abg, column_color, row_color, symmetric_result)
 end
 
 function remap_colors(color::Vector{Int})

--- a/src/result.jl
+++ b/src/result.jl
@@ -58,7 +58,9 @@ function row_groups end
 """
     group_by_color(color::Vector{Int})
 
-Create a color-indexed `group` containing iterables such that `i ∈ group[c]` iff `color[i] == c`.
+Create `group::Vector{Vector{Int}}` such that `i ∈ group[c]` iff `color[i] == c`.
+
+Assumes the colors are contiguously numbered from `1` to some `cmax`.
 """
 function group_by_color(color::AbstractVector{<:Integer})
     cmin, cmax = extrema(color)

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -134,19 +134,19 @@ end
 
     @test nb_vertices(abg) == 4 + 8
     # neighbors of columns
-    @test neighbors(abg, 1) == [1]
-    @test neighbors(abg, 2) == [2]
-    @test neighbors(abg, 3) == [3]
-    @test neighbors(abg, 4) == [4]
-    @test neighbors(abg, 5) == [2, 3, 4]
-    @test neighbors(abg, 6) == [1, 3, 4]
-    @test neighbors(abg, 7) == [1, 2, 4]
-    @test neighbors(abg, 8) == [1, 2, 3]
+    @test collect(neighbors(abg, 1)) == 8 .+ [1]
+    @test collect(neighbors(abg, 2)) == 8 .+ [2]
+    @test collect(neighbors(abg, 3)) == 8 .+ [3]
+    @test collect(neighbors(abg, 4)) == 8 .+ [4]
+    @test collect(neighbors(abg, 5)) == 8 .+ [2, 3, 4]
+    @test collect(neighbors(abg, 6)) == 8 .+ [1, 3, 4]
+    @test collect(neighbors(abg, 7)) == 8 .+ [1, 2, 4]
+    @test collect(neighbors(abg, 8)) == 8 .+ [1, 2, 3]
     # neighbors of rows
-    @test neighbors(abg, 8 + 1) == [1, 6, 7, 8]
-    @test neighbors(abg, 8 + 2) == [2, 5, 7, 8]
-    @test neighbors(abg, 8 + 3) == [3, 5, 6, 8]
-    @test neighbors(abg, 8 + 4) == [4, 5, 6, 7]
+    @test collect(neighbors(abg, 8 + 1)) == [1, 6, 7, 8]
+    @test collect(neighbors(abg, 8 + 2)) == [2, 5, 7, 8]
+    @test collect(neighbors(abg, 8 + 3)) == [3, 5, 6, 8]
+    @test collect(neighbors(abg, 8 + 4)) == [4, 5, 6, 7]
 
     # TODO: remove once we have better tests, this is just to check whether it runs
     @test length(star_coloring(abg, NaturalOrder())[1]) == 12

--- a/test/random.jl
+++ b/test/random.jl
@@ -68,3 +68,21 @@ end;
         test_coloring_decompression(A0, problem, algo)
     end
 end;
+
+@testset "Bicoloring & direct decompression" begin
+    problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
+    algo = GreedyColoringAlgorithm(RandomOrder(rng); decompression=:direct)
+    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
+        A0 = sprand(rng, m, n, p)
+        test_bicoloring_decompression(A0, problem, algo)
+    end
+end;
+
+@testset "Bicoloring & substitution decompression" begin
+    problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
+    algo = GreedyColoringAlgorithm(RandomOrder(rng); decompression=:substitution)
+    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
+        A0 = sprand(rng, m, n, p)
+        test_bicoloring_decompression(A0, problem, algo)
+    end
+end;

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -142,6 +142,24 @@ function test_coloring_decompression(
     end
 end
 
+function test_bicoloring_decompression(
+    A0::AbstractMatrix,
+    problem::ColoringProblem{:nonsymmetric,:bidirectional},
+    algo::GreedyColoringAlgorithm{decompression};
+) where {decompression}
+    @testset "$(typeof(A))" for A in matrix_versions(A0)
+        yield()
+        result = coloring(A, problem, algo; decompression_eltype=Float64)
+        Br, Bc = compress(A, result)
+        @testset "Full decompression" begin
+            @test decompress(Br, Bc, result) ≈ A0
+            @test decompress(Br, Bc, result) ≈ A0  # check result wasn't modified
+            @test decompress!(respectful_similar(A), Br, Bc, result) ≈ A0
+            @test decompress!(respectful_similar(A), Br, Bc, result) ≈ A0
+        end
+    end
+end
+
 function test_structured_coloring_decompression(A::AbstractMatrix)
     column_problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
     row_problem = ColoringProblem(; structure=:nonsymmetric, partition=:row)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -151,6 +151,8 @@ function test_bicoloring_decompression(
         yield()
         result = coloring(A, problem, algo; decompression_eltype=Float64)
         Br, Bc = compress(A, result)
+        @test size(Br, 1) == length(unique(row_colors(result)))
+        @test size(Bc, 2) == length(unique(column_colors(result)))
         @testset "Full decompression" begin
             @test decompress(Br, Bc, result) ≈ A0
             @test decompress(Br, Bc, result) ≈ A0  # check result wasn't modified


### PR DESCRIPTION
> [!NOTE]
> This PR is not about performance, it's about getting stuff to work and adding the necessary tests. We will worry about performance later.

- Fix a bug in `AdjacencyFromBipartiteGraph` (introduced in #144) where the neighbors didn't have the correct offset in the block structure.
- Define a type `BicoloringResult` which contains colors for both columns and rows, as well as a pointer to a `StarSetColoringResult`/`TreeSetColoringResult` associated with the big matrix `[0 A'; A 0]`.
- To go from column colors of `[0 A'; A 0]` to row and column colors of `A`, renumber from `1` on both sides. Example: if `size(A) = (3, 2)` and `color = [1, 2, 4, 3, 2]`, then `column_color = [1, 2, 3]` and `row_color = [2, 1]`. We lose the correspondence with the symmetric matrix, but we gain consistency within each compressed matrix `Br` and `Bc`. 
- Implement `compress`, `decompress` and `decompress!` to work with bidirectional colorings, using the row compression `Br` and the column compression `Bc`.
- For `decompress!`, the implementation is very suboptimal and should be improved in further PRs. Right now it recreates `[0 A'; A 0]`, decompresses into that big matrix and then keeps the bottom left corner. The upside is that it is entirely based on existing code for symmetric decompression.
- Add tests on random instances. It's important to use the random order here to avoid coloring all the columns first and then all the rows.