### PR TITLE
Drop support for Julia 1.6

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: ['lts', '1', 'pre']
+        julia-version: ['1.10', '1']
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           version: ${{ matrix.julia-version }}
           arch: x64
       - uses: julia-actions/julia-downgrade-compat@v1
-        if: ${{ matrix.version == 'lts' }}
+        if: ${{ matrix.version == '1.10' }}
         with:
           skip: LinearAlgebra, Random, SparseArrays
       - uses: julia-actions/cache@v2

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.4.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,10 +13,9 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ADTypes = "1.2.1"
-Compat = "3.46,4.2"
 DataStructures = "0.18"
-LinearAlgebra = "<0.0.1, 1"
 DocStringExtensions = "0.8,0.9"
+LinearAlgebra = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 SparseArrays = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -11,7 +11,6 @@ module SparseMatrixColorings
 
 using ADTypes: ADTypes
 using Base.Iterators: Iterators
-using Compat: @compat, stack
 using DataStructures: DisjointSets, find_root!, root_union!, num_groups
 using DocStringExtensions: README, EXPORTS, SIGNATURES, TYPEDEF, TYPEDFIELDS
 using LinearAlgebra:

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -226,7 +226,7 @@ This function corresponds to algorithm `DirectRecover2` in the paper.
 function symmetric_coefficient(
     i::Integer, j::Integer, color::AbstractVector{<:Integer}, star_set::StarSet
 )
-    @compat (; star, hub) = star_set
+    (; star, hub) = star_set
     if i == j
         # diagonal
         return i, color[j]

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -103,7 +103,7 @@ function coloring(
     decompression_eltype::Type=Float64,
     symmetric_pattern::Bool=false,
 ) where {partition}
-    @compat (; matrix_template, result) = algo
+    (; matrix_template, result) = algo
     if size(A) != size(matrix_template)
         throw(
             DimensionMismatch(

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -264,7 +264,7 @@ end
 ## ColumnColoringResult
 
 function decompress!(A::AbstractMatrix, B::AbstractMatrix, result::ColumnColoringResult)
-    @compat (; color) = result
+    (; color) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     fill!(A, zero(eltype(A)))
@@ -282,7 +282,7 @@ end
 function decompress_single_color!(
     A::AbstractMatrix, b::AbstractVector, c::Integer, result::ColumnColoringResult
 )
-    @compat (; group) = result
+    (; group) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     rvS = rowvals(S)
@@ -296,7 +296,7 @@ function decompress_single_color!(
 end
 
 function decompress!(A::SparseMatrixCSC, B::AbstractMatrix, result::ColumnColoringResult)
-    @compat (; compressed_indices) = result
+    (; compressed_indices) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     nzA = nonzeros(A)
@@ -309,7 +309,7 @@ end
 function decompress_single_color!(
     A::SparseMatrixCSC, b::AbstractVector, c::Integer, result::ColumnColoringResult
 )
-    @compat (; group) = result
+    (; group) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     rvS = rowvals(S)
@@ -326,7 +326,7 @@ end
 ## RowColoringResult
 
 function decompress!(A::AbstractMatrix, B::AbstractMatrix, result::RowColoringResult)
-    @compat (; color) = result
+    (; color) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     fill!(A, zero(eltype(A)))
@@ -344,7 +344,7 @@ end
 function decompress_single_color!(
     A::AbstractMatrix, b::AbstractVector, c::Integer, result::RowColoringResult
 )
-    @compat (; group) = result
+    (; group) = result
     S, Sᵀ = result.bg.S2, result.bg.S1
     check_same_pattern(A, S)
     rvSᵀ = rowvals(Sᵀ)
@@ -358,7 +358,7 @@ function decompress_single_color!(
 end
 
 function decompress!(A::SparseMatrixCSC, B::AbstractMatrix, result::RowColoringResult)
-    @compat (; compressed_indices) = result
+    (; compressed_indices) = result
     S = result.bg.S2
     check_same_pattern(A, S)
     nzA = nonzeros(A)
@@ -373,8 +373,8 @@ end
 function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
-    @compat (; color, star_set) = result
-    @compat (; star, hub, spokes) = star_set
+    (; color, star_set) = result
+    (; star, hub, spokes) = star_set
     S = result.ag.S
     uplo == :F && check_same_pattern(A, S)
     fill!(A, zero(eltype(A)))
@@ -405,8 +405,8 @@ function decompress_single_color!(
     result::StarSetColoringResult,
     uplo::Symbol=:F,
 )
-    @compat (; color, group, star_set) = result
-    @compat (; hub, spokes) = star_set
+    (; color, group, star_set) = result
+    (; hub, spokes) = star_set
     S = result.ag.S
     uplo == :F && check_same_pattern(A, S)
     for i in axes(A, 1)
@@ -433,7 +433,7 @@ end
 function decompress!(
     A::SparseMatrixCSC, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
-    @compat (; compressed_indices) = result
+    (; compressed_indices) = result
     S = result.ag.S
     nzA = nonzeros(A)
     if uplo == :F
@@ -465,7 +465,7 @@ end
 function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::TreeSetColoringResult, uplo::Symbol=:F
 )
-    @compat (; color, vertices_by_tree, reverse_bfs_orders, buffer) = result
+    (; color, vertices_by_tree, reverse_bfs_orders, buffer) = result
     S = result.ag.S
     uplo == :F && check_same_pattern(A, S)
     R = eltype(A)
@@ -512,8 +512,7 @@ function decompress!(
     result::LinearSystemColoringResult,
     uplo::Symbol=:F,
 )
-    @compat (; color, strict_upper_nonzero_inds, T_factorization, strict_upper_nonzeros_A) =
-        result
+    (; color, strict_upper_nonzero_inds, T_factorization, strict_upper_nonzeros_A) = result
     S = result.ag.S
     uplo == :F && check_same_pattern(A, S)
 


### PR DESCRIPTION
Julia 1.11 was released today, and Julia 1.10 announced as the LTS version (see <https://julialang.org/downloads/>)

- Remove Compat.jl from dependencies
- Remove `lts` from CI