### PR TITLE
Allocation-free bidirectional decompression

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -12,9 +12,7 @@ The docstrings on this page describe internals, they are not part of the public 
 ```@docs
 SparseMatrixColorings.SparsityPatternCSC
 SparseMatrixColorings.BipartiteGraph
-SparseMatrixColorings.AbstractAdjacencyGraph
 SparseMatrixColorings.AdjacencyGraph
-SparseMatrixColorings.AdjacencyFromBipartiteGraph
 SparseMatrixColorings.vertices
 SparseMatrixColorings.neighbors
 transpose

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -54,7 +54,7 @@ function partial_distance2_coloring!(
 end
 
 """
-    star_coloring(g::AbstractAdjacencyGraph, order::AbstractOrder)
+    star_coloring(g::AdjacencyGraph, order::AbstractOrder)
 
 Compute a star coloring of all vertices in the adjacency graph `g` and return a tuple `(color, star_set)`, where
 
@@ -67,14 +67,14 @@ The vertices are colored in a greedy fashion, following the `order` supplied.
 
 # See also
 
-- [`AbstractAdjacencyGraph`](@ref)
+- [`AdjacencyGraph`](@ref)
 - [`AbstractOrder`](@ref)
 
 # References
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 4.1
 """
-function star_coloring(g::AbstractAdjacencyGraph, order::AbstractOrder)
+function star_coloring(g::AdjacencyGraph, order::AbstractOrder)
     # Initialize data structures
     nv = nb_vertices(g)
     color = zeros(Int, nv)
@@ -157,7 +157,7 @@ function _treat!(
     treated::AbstractVector{<:Integer},
     forbidden_colors::AbstractVector{<:Integer},
     # not modified
-    g::AbstractAdjacencyGraph,
+    g::AdjacencyGraph,
     v::Integer,
     w::Integer,
     color::AbstractVector{<:Integer},
@@ -175,7 +175,7 @@ function _update_stars!(
     star::Dict{<:Tuple,<:Integer},
     hub::AbstractVector{<:Integer},
     # not modified
-    g::AbstractAdjacencyGraph,
+    g::AdjacencyGraph,
     v::Integer,
     color::AbstractVector{<:Integer},
     first_neighbor::AbstractVector{<:Tuple},
@@ -247,7 +247,7 @@ function symmetric_coefficient(
 end
 
 """
-    acyclic_coloring(g::AbstractAdjacencyGraph, order::AbstractOrder)
+    acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder)
 
 Compute an acyclic coloring of all vertices in the adjacency graph `g` and return a tuple `(color, tree_set)`, where
 
@@ -260,14 +260,14 @@ The vertices are colored in a greedy fashion, following the `order` supplied.
 
 # See also
 
-- [`AbstractAdjacencyGraph`](@ref)
+- [`AdjacencyGraph`](@ref)
 - [`AbstractOrder`](@ref)
 
 # References
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 3.1
 """
-function acyclic_coloring(g::AbstractAdjacencyGraph, order::AbstractOrder)
+function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -668,7 +668,7 @@ function _reconstruct_B!(result::BicoloringResult, Br::AbstractMatrix, Bc::Abstr
     if eltype(result.B) == R
         B = result.B
     else
-        B = similar(R, result.B)
+        B = similar(result.B, R)
     end
     fill!(B, zero(R))
     for c in axes(B, 2)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -31,10 +31,6 @@ SparseArrays.nnz(S::SparsityPatternCSC) = length(S.rowval)
 SparseArrays.rowvals(S::SparsityPatternCSC) = S.rowval
 SparseArrays.nzrange(S::SparsityPatternCSC, j::Integer) = S.colptr[j]:(S.colptr[j + 1] - 1)
 
-function SparseArrays.SparseMatrixCSC(S::SparsityPatternCSC)
-    return SparseMatrixCSC(S.m, S.n, S.colptr, S.rowval, fill(true, nnz(S)))
-end
-
 """
     transpose(S::SparsityPatternCSC)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -238,8 +238,8 @@ function coloring(
         transpose(A)
     end
     A_and_Aᵀ = [
-        spzeros(T, n, n) Aᵀ
-        A spzeros(T, m, m)
+        spzeros(T, n, n) SparseMatrixCSC(Aᵀ)
+        SparseMatrixCSC(A) spzeros(T, m, m)
     ]  # TODO: slow
     ag = AdjacencyGraph(A_and_Aᵀ)
     if decompression == :direct

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -227,26 +227,35 @@ function coloring(
     A::AbstractMatrix,
     ::ColoringProblem{:nonsymmetric,:bidirectional},
     algo::GreedyColoringAlgorithm{decompression};
-    decompression_eltype::Type=Float64,
+    decompression_eltype::Type{R}=Float64,
     symmetric_pattern::Bool=false,
-) where {decompression}
+) where {decompression,R}
     m, n = size(A)
-    abg = AdjacencyFromBipartiteGraph(
-        A; symmetric_pattern=symmetric_pattern || A isa Union{Symmetric,Hermitian}
-    )
-    bigA = SparseMatrixCSC(pattern(abg))  # TODO: slow
-    if decompression == :direct
-        color, star_set = star_coloring(abg, algo.order)
-        symmetric_result = StarSetColoringResult(bigA, abg, color, star_set)
+    T = eltype(A)
+    Aᵀ = if symmetric_pattern || A isa Union{Symmetric,Hermitian}
+        A
     else
-        color, tree_set = acyclic_coloring(abg, algo.order)
+        transpose(A)
+    end
+    A_and_Aᵀ = [
+        spzeros(T, n, n) Aᵀ
+        A spzeros(T, m, m)
+    ]  # TODO: slow
+    ag = AdjacencyGraph(A_and_Aᵀ)
+    if decompression == :direct
+        color, star_set = star_coloring(ag, algo.order)
+        symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)
+    else
+        color, tree_set = acyclic_coloring(ag, algo.order)
         symmetric_result = TreeSetColoringResult(
-            bigA, abg, color, tree_set, decompression_eltype
+            A_and_Aᵀ, ag, color, tree_set, decompression_eltype
         )
     end
     column_color, _ = remap_colors(color[1:n])
     row_color, _ = remap_colors(color[(n + 1):(n + m)])
-    return BicoloringResult(A, abg, column_color, row_color, symmetric_result)
+    return BicoloringResult(
+        A, ag, column_color, row_color, symmetric_result, decompression_eltype
+    )
 end
 
 function remap_colors(color::Vector{Int})

--- a/src/order.jl
+++ b/src/order.jl
@@ -24,7 +24,7 @@ Instance of [`AbstractOrder`](@ref) which sorts vertices using their index in th
 """
 struct NaturalOrder <: AbstractOrder end
 
-function vertices(g::AbstractAdjacencyGraph, ::NaturalOrder)
+function vertices(g::AdjacencyGraph, ::NaturalOrder)
     return vertices(g)
 end
 
@@ -43,7 +43,7 @@ end
 
 RandomOrder() = RandomOrder(default_rng())
 
-function vertices(g::AbstractAdjacencyGraph, order::RandomOrder)
+function vertices(g::AdjacencyGraph, order::RandomOrder)
     return randperm(order.rng, nb_vertices(g))
 end
 
@@ -58,7 +58,7 @@ Instance of [`AbstractOrder`](@ref) which sorts vertices using their degree in t
 """
 struct LargestFirst <: AbstractOrder end
 
-function vertices(g::AbstractAdjacencyGraph, ::LargestFirst)
+function vertices(g::AdjacencyGraph, ::LargestFirst)
     criterion(v) = degree(g, v)
     return sort(vertices(g); by=criterion, rev=true)
 end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -3,7 +3,6 @@ using SparseArrays
 using SparseMatrixColorings:
     SparsityPatternCSC,
     AdjacencyGraph,
-    AdjacencyFromBipartiteGraph,
     BipartiteGraph,
     degree,
     degree_dist2,

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -121,34 +121,3 @@ end;
     @test collect(neighbors(g, 7)) == [1, 2, 4, 5, 6, 8]
     @test collect(neighbors(g, 8)) == [1, 2, 3, 5, 6, 7]
 end
-
-@testset "AdjacencyFromBipartiteGraph" begin
-    A = sparse([
-        1 0 0 0 0 1 1 1
-        0 1 0 0 1 0 1 1
-        0 0 1 0 1 1 0 1
-        0 0 0 1 1 1 1 0
-    ])
-
-    abg = AdjacencyFromBipartiteGraph(A)
-
-    @test nb_vertices(abg) == 4 + 8
-    # neighbors of columns
-    @test collect(neighbors(abg, 1)) == 8 .+ [1]
-    @test collect(neighbors(abg, 2)) == 8 .+ [2]
-    @test collect(neighbors(abg, 3)) == 8 .+ [3]
-    @test collect(neighbors(abg, 4)) == 8 .+ [4]
-    @test collect(neighbors(abg, 5)) == 8 .+ [2, 3, 4]
-    @test collect(neighbors(abg, 6)) == 8 .+ [1, 3, 4]
-    @test collect(neighbors(abg, 7)) == 8 .+ [1, 2, 4]
-    @test collect(neighbors(abg, 8)) == 8 .+ [1, 2, 3]
-    # neighbors of rows
-    @test collect(neighbors(abg, 8 + 1)) == [1, 6, 7, 8]
-    @test collect(neighbors(abg, 8 + 2)) == [2, 5, 7, 8]
-    @test collect(neighbors(abg, 8 + 3)) == [3, 5, 6, 8]
-    @test collect(neighbors(abg, 8 + 4)) == [4, 5, 6, 7]
-
-    # TODO: remove once we have better tests, this is just to check whether it runs
-    @test length(star_coloring(abg, NaturalOrder())[1]) == 12
-    @test length(acyclic_coloring(abg, NaturalOrder())[1]) == 12
-end

--- a/test/random.jl
+++ b/test/random.jl
@@ -76,6 +76,11 @@ end;
         A0 = sprand(rng, m, n, p)
         test_bicoloring_decompression(A0, problem, algo)
     end
+    @testset "$((; n, p))" for (n, p) in symmetric_params
+        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+        color0 = column_coloring(A0, algo)
+        test_bicoloring_decompression(A0, problem, algo)
+    end
 end;
 
 @testset "Bicoloring & substitution decompression" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,7 +26,7 @@ function test_coloring_decompression(
 
         if structure == :nonsymmetric && issymmetric(A)
             result = coloring(
-                A, problem, algo; decompression_eltype=Float64, symmetric_pattern=true
+                A, problem, algo; decompression_eltype=Float32, symmetric_pattern=true
             )
         else
             result = coloring(A, problem, algo; decompression_eltype=Float64)
@@ -149,7 +149,13 @@ function test_bicoloring_decompression(
 ) where {decompression}
     @testset "$(typeof(A))" for A in matrix_versions(A0)
         yield()
-        result = coloring(A, problem, algo; decompression_eltype=Float64)
+        if issymmetric(A)
+            result = coloring(
+                A, problem, algo; decompression_eltype=Float32, symmetric_pattern=true
+            )
+        else
+            result = coloring(A, problem, algo; decompression_eltype=Float64)
+        end
         Br, Bc = compress(A, result)
         @test size(Br, 1) == length(unique(row_colors(result)))
         @test size(Bc, 2) == length(unique(column_colors(result)))


### PR DESCRIPTION
- Remove adjacency graph from bipartite introduced in #144 because we need an actual `SparseMatrixCSC` containing `A` and `Aᵀ` for efficient decompression.
- Precompute more stuff and allocate all necessary storage when creating a `BicoloringResult`.
- To decompress a `BicoloringResult` into a `SparseMatrixCSC`, actually decompress into a larger matrix `A_and_noAᵀ`, which contains the lower triangle of `A_and_Aᵀ`. This larger matrix shares the vector `A.nzval`, so that `A` is updated in-place.
- Add type stability and allocation tests for bicoloring. At the moment, only decompression into a `SparseMatrixCSC` is alloc-free. Decompression into a `Matrix` still requires taking the bottom left submatrix of `A_and_noAᵀ` (it also could be a view but views of sparse matrices are inefficient).