### PR TITLE
Add a function structurally_biorthogonal for star bicoloring

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -48,6 +48,7 @@ SparseMatrixColorings.remap_colors
 SparseMatrixColorings.directly_recoverable_columns
 SparseMatrixColorings.symmetrically_orthogonal_columns
 SparseMatrixColorings.structurally_orthogonal_columns
+SparseMatrixColorings.structurally_biorthogonal
 SparseMatrixColorings.valid_dynamic_order
 ```
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -100,7 +100,7 @@ end
 
 Undirected graph without self-loops representing the nonzeros of a symmetric matrix (typically a Hessian matrix).
 
-The adjacency graph of a symmetrix matric `A ∈ ℝ^{n × n}` is `G(A) = (V, E)` where
+The adjacency graph of a symmetric matrix `A ∈ ℝ^{n × n}` is `G(A) = (V, E)` where
 
 - `V = 1:n` is the set of rows or columns `i`/`j`
 - `(i, j) ∈ E` whenever `A[i, j] ≠ 0` and `i ≠ j`

--- a/test/check.jl
+++ b/test/check.jl
@@ -2,6 +2,7 @@ using LinearAlgebra
 using SparseMatrixColorings:
     structurally_orthogonal_columns,
     symmetrically_orthogonal_columns,
+    structurally_biorthogonal,
     directly_recoverable_columns,
     what_fig_41,
     efficient_fig_1
@@ -121,4 +122,16 @@ For coefficient (i=2, j=3) with column colors (ci=3, cj=1):
     @test !directly_recoverable_columns(A, [1, 2, 1, 3, 1, 4, 3, 4, 1, 2])
     @test !directly_recoverable_columns(A, [1, 2, 1, 3, 1, 4, 2, 5, 1, 2])
     @test !directly_recoverable_columns(A, [1, 2, 1, 4, 1, 4, 3, 5, 1, 2])
+end
+
+@testset "Structurally biorthogonal" begin
+    A = [
+        1 5 7 9 11
+        2 0 0 0 12
+        3 0 0 0 13
+        4 6 8 10 14
+    ]
+
+    # success
+    @test structurally_biorthogonal(A, [1, 2, 2, 3], [1, 2, 2, 2, 3])
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -59,13 +59,16 @@ function test_coloring_decompression(
                     if partition == :column
                         @test structurally_orthogonal_columns(A0, color)
                         @test directly_recoverable_columns(A0, color)
-                    else
+                    elseif partition == :row
                         @test structurally_orthogonal_columns(transpose(A0), color)
                         @test directly_recoverable_columns(transpose(A0), color)
                     end
                 else
-                    @test symmetrically_orthogonal_columns(A0, color)
-                    @test directly_recoverable_columns(A0, color)
+                    # structure == :symmetric
+                    if partition == :column
+                        @test symmetrically_orthogonal_columns(A0, color)
+                        @test directly_recoverable_columns(A0, color)
+                    end
                 end
             end
         end


### PR DESCRIPTION
- Fix three typos (`symmetrix` and `matric`).
- Add a function `proper_length_bicoloring` to check the length of the two color vectors returned by a bicoloring.
- Add a function `structurally_biorthogonal` based on a "new" definition of star bicoloring.

I don't need to know if a star bicoloring on `A` was already defined like this before; it’s something we could easily derive from the definition of a symmetric star coloring on `[0 A'; A 0]`.