### PR TITLE
Improve how we build A_and_Aᵀ

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -16,6 +16,7 @@ SparseMatrixColorings.BipartiteGraph
 SparseMatrixColorings.vertices
 SparseMatrixColorings.neighbors
 transpose
+SparseMatrixColorings.bidirectional_pattern
 ```
 
 ## Low-level coloring

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -14,7 +14,7 @@ Copied from `SparseMatrixCSC`:
 - `colptr::Vector{Ti}`: column `j` is in `colptr[j]:(colptr[j+1]-1)`
 - `rowval::Vector{Ti}`: row indices of stored values
 """
-struct SparsityPatternCSC{Ti<:Integer}
+struct SparsityPatternCSC{Ti<:Integer} <: AbstractMatrix{Bool}
     m::Int
     n::Int
     colptr::Vector{Ti}

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -93,6 +93,76 @@ function Base.getindex(S::SparsityPatternCSC, i0::Integer, i1::Integer)
     return ((r1 > r2) || (rowvals(S)[r1] != i0)) ? false : true
 end
 
+"""
+    bidirectional_pattern(A::AbstractMatrix; symmetric_pattern::Bool)
+
+Return a [`SparsityPatternCSC`](@ref) corresponding to the matrix `[0 Aᵀ; A 0]`, with a minimum of allocations.
+"""
+bidirectional_pattern(A::AbstractMatrix; symmetric_pattern) =
+    bidirectional_pattern(SparsityPatternCSC(SparseMatrixCSC(A)); symmetric_pattern)
+
+function bidirectional_pattern(S::SparsityPatternCSC; symmetric_pattern)
+    m, n = size(S)
+    p = m + n
+    nnzS = nnz(S)
+    rowval = Vector{Int}(undef, 2 * nnzS)
+    colptr = zeros(Int, p + 1)
+
+    # Update rowval and colptr for the block A
+    for i in 1:nnzS
+        rowval[i] = S.rowval[i] + n
+    end
+    for j in 1:n
+        colptr[j] = S.colptr[j]
+    end
+
+    # Update rowval and colptr for the block Aᵀ
+    if symmetric_pattern
+        # We use the sparsity pattern of A for Aᵀ
+        for i in 1:nnzS
+            rowval[nnzS + i] = S.rowval[i]
+        end
+        # m and n are identical because symmetric_pattern is true
+        for j in 1:m
+            colptr[n + j] = nnzS + S.colptr[j]
+        end
+        colptr[p + 1] = 2 * nnzS + 1
+    else
+        # We need to determine the sparsity pattern of Aᵀ
+        # We adapt the code of transpose(SparsityPatternCSC) in graph.jl
+        for k in 1:nnzS
+            i = S.rowval[k]
+            colptr[n + i] += 1
+        end
+
+        counter = 1
+        for col in (n + 1):p
+            nnz_col = colptr[col]
+            colptr[col] = counter
+            counter += nnz_col
+        end
+
+        for j in 1:n
+            for index in S.colptr[j]:(S.colptr[j + 1] - 1)
+                i = S.rowval[index]
+                pos = colptr[n + i]
+                rowval[nnzS + pos] = j
+                colptr[n + i] += 1
+            end
+        end
+
+        colptr[p + 1] = nnzS + counter
+        for col in p:-1:(n + 2)
+            colptr[col] = nnzS + colptr[col - 1]
+        end
+        colptr[n + 1] = nnzS + 1
+    end
+
+    # Create the SparsityPatternCSC of the augmented adjacency matrix
+    S_and_Sᵀ = SparsityPatternCSC{Int}(p, p, colptr, rowval)
+    return S_and_Sᵀ
+end
+
 ## Adjacency graph
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -234,70 +234,8 @@ function coloring(
     decompression_eltype::Type{R}=Float64,
     symmetric_pattern::Bool=false,
 ) where {decompression,R}
-
-    # Build an AdjacencyGraph for the following matrix:
-    # [ 0  Aᵀ ]
-    # [ A  0  ]
-    m, n = size(A)
-    p = m + n
-    S = A isa SparseMatrixCSC ? A : SparseMatrixCSC(A)
-    nnzS = nnz(S)
-    rowval = Vector{Int}(undef, 2 * nnzS)
-    colptr = zeros(Int, p + 1)
-
-    # Update rowval and colptr for the block A
-    for i in 1:nnzS
-        rowval[i] = S.rowval[i] + n
-    end
-    for j in 1:n
-        colptr[j] = S.colptr[j]
-    end
-
-    # Update rowval and colptr for the block Aᵀ
-    if symmetric_pattern
-        # We use the sparsity pattern of A for Aᵀ
-        for i in 1:nnzS
-            rowval[nnzS + i] = S.rowval[i]
-        end
-        # m and n are identical because symmetric_pattern is true
-        for j in 1:m
-            colptr[n + j] = nnzS + S.colptr[j]
-        end
-        colptr[p + 1] = 2 * nnzS + 1
-    else
-        # We need to determine the sparsity pattern of Aᵀ
-        # We adapt the code of transpose(SparsityPatternCSC) in graph.jl
-        for k in 1:nnzS
-            i = S.rowval[k]
-            colptr[n + i] += 1
-        end
-
-        counter = 1
-        for col in (n + 1):p
-            nnz_col = colptr[col]
-            colptr[col] = counter
-            counter += nnz_col
-        end
-
-        for j in 1:n
-            for index in S.colptr[j]:(S.colptr[j + 1] - 1)
-                i = S.rowval[index]
-                pos = colptr[n + i]
-                rowval[nnzS + pos] = j
-                colptr[n + i] += 1
-            end
-        end
-
-        colptr[p + 1] = nnzS + counter
-        for col in p:-1:(n + 2)
-            colptr[col] = nnzS + colptr[col - 1]
-        end
-        colptr[n + 1] = nnzS + 1
-    end
-
-    # Create the SparsityPatternCSC of the augmented adjacency matrix
-    A_and_Aᵀ = SparsityPatternCSC{Int}(p, p, colptr, rowval)
-    ag = AdjacencyGraph(A_and_Aᵀ)
+    A_and_Aᵀ = bidirectional_pattern(A; symmetric_pattern)
+    ag = AdjacencyGraph(A_and_Aᵀ; has_diagonal=false)
 
     if decompression == :direct
         color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -289,7 +289,6 @@ function coloring(
         end
 
         colptr[p + 1] = nnzS + counter
-        @assert colptr[p + 1] == 2 * nnzS + 1
         for col in p:-1:(n + 2)
             colptr[col] = nnzS + colptr[col - 1]
         end


### PR DESCRIPTION
close #161 

If we want to store exactly `[0 A'; A 0]`, we can't use `symmetric_pattern` to build `Aᵀ`.
```julia
Aᵀ = if symmetric_pattern || A isa Union{Symmetric,Hermitian}
  A
else
  transpose(A)
end
```
We will have the wrong nonzeros in `A_and_Aᵀ` (but the correct sparsity pattern).

I'm wondering if we should store a different matrix than `b = A_and_Aᵀ` in `StarSetResult` or `TreeSetResult`.  
If I remember correctly, we want to store `B` to have the correct type for the function `decompress`, but in this case, it’s always a `SparseMatrixCSC`, whereas `A` could have a different type.

We probably only want the `AdjacencyGraph` of `A_and_Aᵀ` and not the matrix itself, and we could likely achieve this with a keyword argument for `AdjacencyGraph` or another constructor that takes two arguments (`A` and `Aᵀ`).

Off-topic: We can modify the function  `neighbors(g::AdjacencyGraph, v::Integer)` to not use `filter` in the case of bicoloring because we know that we don't have diagonal coefficients.