### PR TITLE
feat: allow neutral colors and postprocessing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle", "Alexis Montoison"]
-version = "0.4.12"
+version = "0.4.13"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/vis.md
+++ b/docs/src/vis.md
@@ -73,7 +73,7 @@ S = sparse([
 ])
 
 problem_bi = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
-algo_bi = GreedyColoringAlgorithm(RandomOrder(StableRNG(0)); decompression=:direct)
+algo_bi = GreedyColoringAlgorithm(RandomOrder(StableRNG(0)); postprocessing=true, decompression=:direct)
 result_bi = coloring(S, problem_bi, algo_bi)
 
 A_img, Br_img, Bc_img = show_colors(

--- a/docs/src/vis.md
+++ b/docs/src/vis.md
@@ -61,10 +61,8 @@ Finally, a background color can be passed via the `background` keyword argument.
 We demonstrate this on a bidirectional coloring.
 
 ```@example img
-
 S = sparse([
     1 1 1 1 1 1 1 1 1
-    1 0 0 0 0 0 0 0 1
     1 0 0 0 0 0 0 0 1
     1 0 0 0 0 0 0 0 1
     1 0 0 0 0 0 0 0 1

--- a/ext/SparseMatrixColoringsColorsExt.jl
+++ b/ext/SparseMatrixColoringsColorsExt.jl
@@ -131,7 +131,9 @@ function show_colors!(
         if !iszero(A[I])
             r, c = Tuple(I)
             area = matrix_entry_area(I, scale, pad)
-            A_img[area] .= A_colors[c]
+            if column_colors(res)[c] > 0
+                A_img[area] .= A_colors[c]
+            end
         end
     end
     for I in CartesianIndices(B)
@@ -163,7 +165,9 @@ function show_colors!(
         if !iszero(A[I])
             r, c = Tuple(I)
             area = matrix_entry_area(I, scale, pad)
-            A_img[area] .= A_colors[r]
+            if row_colors(res)[r] > 0
+                A_img[area] .= A_colors[r]
+            end
         end
     end
     for I in CartesianIndices(B)
@@ -205,9 +209,13 @@ function show_colors!(
             area = matrix_entry_area(I, scale, pad)
             for i in axes(area, 1), j in axes(area, 2)
                 if j > i
-                    A_img[area[i, j]] = A_ccolors[c]
+                    if column_colors(res)[c] > 0
+                        A_img[area[i, j]] = A_ccolors[c]
+                    end
                 elseif i > j
-                    A_img[area[i, j]] = A_rcolors[r]
+                    if row_colors(res)[r] > 0
+                        A_img[area[i, j]] = A_rcolors[r]
+                    end
                 end
             end
         end

--- a/src/check.jl
+++ b/src/check.jl
@@ -253,7 +253,7 @@ function directly_recoverable_columns(
     B_unique = Set(unique(B))
     if !issubset(A_unique, push!(B_unique, zero(eltype(B))))
         if verbose
-            @warn "Coefficients $(sort(collect(setdiff(A_unique, B_unique)))) are not directly recoverable." A_unique B_unique
+            @warn "Coefficients $(sort(collect(setdiff(A_unique, B_unique)))) are not directly recoverable."
             return false
         end
         return false

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -535,7 +535,7 @@ function postprocess!(
 )
     (; S) = g
     # flag which colors are actually used during decompression
-    color_used = zeros(Bool, maximum(color))
+    color_used = falses(maximum(color))
     # nonzero diagonal coefficients force the use of their respective color (there can be no neutral colors if the diagonal is fully nonzero)
     for i in axes(S, 1)
         if !iszero(S[i, i])

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -65,7 +65,7 @@ A _star coloring_ is a distance-1 coloring such that every path on 4 vertices us
 
 The vertices are colored in a greedy fashion, following the `order` supplied.
 
-If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" colors) as long as they are not needed during decompression.
+If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" color) as long as they are not needed during decompression.
 
 # See also
 
@@ -104,7 +104,7 @@ function star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::
                 for x in neighbors(g, w)
                     (x == v || iszero(color[x])) && continue
                     wx = _sort(w, x)
-                    if x == hub[star[wx]]  # potential Case 2 (will always be false if the hub is negative)
+                    if x == hub[star[wx]]  # potential Case 2 (which is always false for trivial stars with two vertices, since the associated hub is negative)
                         forbidden_colors[color[x]] = v
                     end
                 end
@@ -207,7 +207,7 @@ function _update_stars!(
                 hub[star[vq]] = v  # this may already be true
                 star[vw] = star[vq]
             else  # vw forms a new star
-                push!(hub, -max(v, w))  # star is trivial so we set the hub to a negative value, but it allows us to choose one of the two vertices
+                push!(hub, -max(v, w))  # star is trivial (composed only of two vertices) so we set the hub to a negative value, but it allows us to choose one of the two vertices
                 star[vw] = length(hub)
             end
         end
@@ -265,7 +265,7 @@ An _acyclic coloring_ is a distance-1 coloring with the further restriction that
 
 The vertices are colored in a greedy fashion, following the `order` supplied.
 
-If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" colors) as long as they are not needed during decompression.
+If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" color) as long as they are not needed during decompression.
 
 # See also
 
@@ -550,7 +550,7 @@ function postprocess!(
             color_used[color[j]] = true
         end
     else
-        # only the colors inside the trees are used
+        # only the colors of non-leaf vertices are used
         (; reverse_bfs_orders) = star_or_tree_set
         for k in eachindex(reverse_bfs_orders)
             for (i, j) in reverse_bfs_orders[k]

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -535,7 +535,8 @@ function postprocess!(
 )
     (; S) = g
     # flag which colors are actually used during decompression
-    color_used = falses(maximum(color))
+    color_used = zeros(Bool, maximum(color))
+
     # nonzero diagonal coefficients force the use of their respective color (there can be no neutral colors if the diagonal is fully nonzero)
     for i in axes(S, 1)
         if !iszero(S[i, i])

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -417,7 +417,7 @@ struct TreeSet
     reverse_bfs_orders::Vector{Vector{Tuple{Int,Int}}}
 end
 
-function TreeSet(forest::DisjointSets{Tuple{Int,Int}}, nvertices::Integer)
+function TreeSet(forest::DisjointSets{Tuple{Int,Int}}, nvertices::Int)
     # forest is a structure DisjointSets from DataStructures.jl
     # - forest.intmap: a dictionary that maps an edge (i, j) to an integer k
     # - forest.revmap: a dictionary that does the reverse of intmap, mapping an integer k to an edge (i, j)

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -558,14 +558,17 @@ function postprocess!(
             end
         end
     end
-    # assign the neutral color to every vertex with a useless color
-    for i in eachindex(color)
-        ci = color[i]
-        if !color_used[ci]
-            color[i] = 0
+    # if at least one of the colors is useless, modify the color assignments of vertices
+    if any(!, color_used)
+        # assign the neutral color to every vertex with a useless color
+        for i in eachindex(color)
+            ci = color[i]
+            if !color_used[ci]
+                color[i] = 0
+            end
         end
+        # remap colors to decrease the highest one by filling gaps
+        color .= remap_colors(color)[1]
     end
-    # remap colors to decrease the highest one by filling gaps
-    color .= remap_colors(color)[1]
     return color
 end

--- a/src/result.jl
+++ b/src/result.jl
@@ -44,23 +44,23 @@ function row_colors end
 """
     column_groups(result::AbstractColoringResult)
 
-Return a vector `group` such that for every color `c`, `group[c]` contains the indices of all columns that are colored with `c`.
+Return a vector `group` such that for every non-zero color `c`, `group[c]` contains the indices of all columns that are colored with `c`.
 """
 function column_groups end
 
 """
     row_groups(result::AbstractColoringResult)
 
-Return a vector `group` such that for every color `c`, `group[c]` contains the indices of all rows that are colored with `c`.
+Return a vector `group` such that for every non-zero color `c`, `group[c]` contains the indices of all rows that are colored with `c`.
 """
 function row_groups end
 
 """
     ncolors(result::AbstractColoringResult)
 
-Return the number of different colors used to color the matrix.
+Return the number of different non-zero colors used to color the matrix.
 
-For bidirectional partitions, this number is the sum of the number of row colors and the number of column colors.
+For bidirectional partitions, this number is the sum of the number of non-zero row colors and the number of non-zero column colors.
 """
 function ncolors(res::AbstractColoringResult{structure,:column}) where {structure}
     return length(column_groups(res))
@@ -77,32 +77,35 @@ end
 """
     group_by_color(color::Vector{Int})
 
-Create a color-indexed vector `group` such that `i ∈ group[c]` iff `color[i] == c`.
+Create a color-indexed vector `group` such that `i ∈ group[c]` iff `color[i] == c` for all `c > 0`.
 
-Assumes the colors are contiguously numbered from `1` to some `cmax`.
+Assumes the colors are contiguously numbered from `0` to some `cmax`.
 """
 function group_by_color(color::AbstractVector{<:Integer})
     cmin, cmax = extrema(color)
-    @assert cmin >= 1
+    @assert cmin >= 0
     # Compute group sizes and offsets for a joint storage
     group_sizes = zeros(Int, cmax)  # allocation 1, size cmax
     for c in color
-        group_sizes[c] += 1
+        if c > 0
+            group_sizes[c] += 1
+        end
     end
     group_offsets = cumsum(group_sizes)  # allocation 2, size cmax
     # Concatenate all groups inside a single vector
-    group_flat = similar(color)  # allocation 3, size n
+    group_flat = similar(color, sum(group_sizes))  # allocation 3, size <= n
     for (k, c) in enumerate(color)
-        i = group_offsets[c] - group_sizes[c] + 1
-        group_flat[i] = k
-        group_sizes[c] -= 1
+        if c > 0
+            i = group_offsets[c] - group_sizes[c] + 1
+            group_flat[i] = k
+            group_sizes[c] -= 1
+        end
     end
     # Create views into contiguous blocks of the group vector
-    group = Vector{typeof(view(group_flat, 1:1))}(undef, cmax)  # allocation 4, size cmax
-    for c in 1:cmax
+    group = map(1:cmax) do c
         i = 1 + (c == 1 ? 0 : group_offsets[c - 1])
         j = group_offsets[c]
-        group[c] = view(group_flat, i:j)
+        view(group_flat, i:j)
     end
     return group
 end
@@ -291,6 +294,7 @@ function TreeSetColoringResult(
     tree_set::TreeSet,
     decompression_eltype::Type{R},
 ) where {R}
+    (; vertices_by_tree, reverse_bfs_orders) = tree_set
     S = ag.S
     nvertices = length(color)
     group = group_by_color(color)
@@ -300,7 +304,6 @@ function TreeSetColoringResult(
     diagonal_nzind = Int[]
     ndiag = 0
 
-    n = size(S, 1)
     rv = rowvals(S)
     for j in axes(S, 2)
         for k in nzrange(S, j)
@@ -318,142 +321,40 @@ function TreeSetColoringResult(
     lower_triangle_offsets = Vector{Int}(undef, nedges)
     upper_triangle_offsets = Vector{Int}(undef, nedges)
 
-    # forest is a structure DisjointSets from DataStructures.jl
-    # - forest.intmap: a dictionary that maps an edge (i, j) to an integer k
-    # - forest.revmap: a dictionary that does the reverse of intmap, mapping an integer k to an edge (i, j)
-    # - forest.internal.ngroups: the number of trees in the forest
-    forest = tree_set.forest
-    ntrees = forest.internal.ngroups
-
-    # dictionary that maps a tree's root to the index of the tree
-    roots = Dict{Int,Int}()
-
-    # vector of dictionaries where each dictionary stores the neighbors of each vertex in a tree
-    trees = [Dict{Int,Vector{Int}}() for i in 1:ntrees]
-
-    # counter of the number of roots found
-    k = 0
-    for edge in forest.revmap
-        i, j = edge
-        # forest has already been compressed so this doesn't change its state
-        # I wanted to use find_root but it is deprecated
-        root_edge = find_root!(forest, edge)
-        root = forest.intmap[root_edge]
-
-        # Update roots
-        if !haskey(roots, root)
-            k += 1
-            roots[root] = k
-        end
-
-        # index of the tree T that contains this edge
-        index_tree = roots[root]
-
-        # Update the neighbors of i in the tree T
-        if !haskey(trees[index_tree], i)
-            trees[index_tree][i] = [j]
-        else
-            push!(trees[index_tree][i], j)
-        end
-
-        # Update the neighbors of j in the tree T
-        if !haskey(trees[index_tree], j)
-            trees[index_tree][j] = [i]
-        else
-            push!(trees[index_tree][j], i)
-        end
-    end
-
-    # degrees is a vector of integers that stores the degree of each vertex in a tree
-    degrees = Vector{Int}(undef, nvertices)
-
-    # list of vertices for each tree in the forest
-    vertices_by_tree = [collect(keys(trees[i])) for i in 1:ntrees]
-
-    # reverse breadth first (BFS) traversal order for each tree in the forest
-    reverse_bfs_orders = [Tuple{Int,Int}[] for i in 1:ntrees]
-
-    # nvmax is the number of vertices of the biggest tree in the forest
-    nvmax = mapreduce(length, max, vertices_by_tree; init=0)
-
-    # Create a queue with a fixed size nvmax
-    queue = Vector{Int}(undef, nvmax)
-
     # Index in lower_triangle_offsets and upper_triangle_offsets
     index_offsets = 0
 
-    for k in 1:ntrees
-        tree = trees[k]
+    for k in eachindex(reverse_bfs_orders)
+        for (leaf, neighbor) in reverse_bfs_orders[k]
+            # Update lower_triangle_offsets and upper_triangle_offsets
+            i = leaf
+            j = neighbor
+            col_i = view(rv, nzrange(S, i))
+            col_j = view(rv, nzrange(S, j))
+            index_offsets += 1
 
-        # Initialize the queue to store the leaves
-        queue_start = 1
-        queue_end = 0
+            #! format: off
+            # S[i,j] is in the lower triangular part of S
+            if in_triangle(i, j, :L)
+                # uplo = :L or uplo = :F
+                # S[i,j] is stored at index_ij = (S.colptr[j+1] - offset_L) in S.nzval
+                lower_triangle_offsets[index_offsets] = length(col_j) - searchsortedfirst(col_j, i) + 1
 
-        # compute the degree of each vertex in the tree
-        for (vertex, neighbors) in tree
-            degree = length(neighbors)
-            degrees[vertex] = degree
+                # uplo = :U or uplo = :F
+                # S[j,i] is stored at index_ji = (S.colptr[i] + offset_U) in S.nzval
+                upper_triangle_offsets[index_offsets] = searchsortedfirst(col_i, j)::Int - 1
 
-            # the vertex is a leaf
-            if degree == 1
-                queue_end += 1
-                queue[queue_end] = vertex
+            # S[i,j] is in the upper triangular part of S
+            else
+                # uplo = :U or uplo = :F
+                # S[i,j] is stored at index_ij = (S.colptr[j] + offset_U) in S.nzval
+                upper_triangle_offsets[index_offsets] = searchsortedfirst(col_j, i)::Int - 1
+
+                # uplo = :L or uplo = :F
+                # S[j,i] is stored at index_ji = (S.colptr[i+1] - offset_L) in S.nzval
+                lower_triangle_offsets[index_offsets] = length(col_i) - searchsortedfirst(col_i, j) + 1
             end
-        end
-
-        # continue until all leaves are treated
-        while queue_start <= queue_end
-            leaf = queue[queue_start]
-            queue_start += 1
-
-            # Mark the vertex as removed
-            degrees[leaf] = 0
-
-            for neighbor in tree[leaf]
-                if degrees[neighbor] != 0
-                    # (leaf, neighbor) represents the next edge to visit during decompression
-                    push!(reverse_bfs_orders[k], (leaf, neighbor))
-
-                    # reduce the degree of the neighbor
-                    degrees[neighbor] -= 1
-
-                    # check if the neighbor is now a leaf
-                    if degrees[neighbor] == 1
-                        queue_end += 1
-                        queue[queue_end] = neighbor
-                    end
-
-                    # Update lower_triangle_offsets and upper_triangle_offsets
-                    i = leaf
-                    j = neighbor
-                    col_i = view(rv, nzrange(S, i))
-                    col_j = view(rv, nzrange(S, j))
-                    index_offsets += 1
-
-                    #! format: off
-                    # S[i,j] is in the lower triangular part of S
-                    if in_triangle(i, j, :L)
-                        # uplo = :L or uplo = :F
-                        # S[i,j] is stored at index_ij = (S.colptr[j+1] - offset_L) in S.nzval
-                        lower_triangle_offsets[index_offsets] = length(col_j) - searchsortedfirst(col_j, i) + 1
-
-                        # uplo = :U or uplo = :F
-                        # S[j,i] is stored at index_ji = (S.colptr[i] + offset_U) in S.nzval
-                        upper_triangle_offsets[index_offsets] = searchsortedfirst(col_i, j)::Int - 1
-
-                    # S[i,j] is in the upper triangular part of S
-                    else
-                        # uplo = :U or uplo = :F
-                        # S[i,j] is stored at index_ij = (S.colptr[j] + offset_U) in S.nzval
-                        upper_triangle_offsets[index_offsets] = searchsortedfirst(col_j, i)::Int - 1
-
-                        # uplo = :L or uplo = :F
-                        # S[j,i] is stored at index_ji = (S.colptr[i+1] - offset_L) in S.nzval
-                        lower_triangle_offsets[index_offsets] = length(col_i) - searchsortedfirst(col_i, j) + 1
-                    end
-                    #! format: on
-                end
-            end
+            #! format: on
         end
     end
 
@@ -553,7 +454,7 @@ end
 """
     remap_colors(color::Vector{Int})
 
-Renumber the colors in `color` using their index in the vector `sort(unique(color))`, so that they are forced to go from `1` to some `cmax` contiguously.
+Renumber the colors in `color` using their index in the vector `sort(unique(color))`, so that the non-zero colors are forced to go from `1` to some `cmax` contiguously.
 
 Return a tuple `(remapped_colors, color_to_ind)` such that `remapped_colors` is a vector containing the renumbered colors and `color_to_ind` is a dictionary giving the translation between old and new color numberings.
 
@@ -562,7 +463,8 @@ For all vertex indices `i` we have:
     remapped_color[i] = color_to_ind[color[i]]
 """
 function remap_colors(color::Vector{Int})
-    color_to_ind = Dict(c => i for (i, c) in enumerate(sort(unique(color))))
+    color_to_ind = Dict(c => i for (i, c) in enumerate(sort(unique(color[color .> 0]))))
+    color_to_ind[0] = 0
     remapped_colors = [color_to_ind[c] for c in color]
     return remapped_colors, color_to_ind
 end

--- a/src/result.jl
+++ b/src/result.jl
@@ -429,10 +429,14 @@ function LinearSystemColoringResult(
     for (l, (i, j)) in enumerate(strict_upper_nonzero_inds)
         ci = color[i]
         cj = color[j]
-        ki = (ci - 1) * n + j  # A[i, j] appears in B[j, ci]
-        kj = (cj - 1) * n + i  # A[i, j] appears in B[i, cj]
-        T[ki, l] = 1
-        T[kj, l] = 1
+        if ci > 0
+            ki = (ci - 1) * n + j  # A[i, j] appears in B[j, ci]
+            T[ki, l] = 1
+        end
+        if cj > 0
+            kj = (cj - 1) * n + i  # A[i, j] appears in B[i, cj]
+            T[kj, l] = 1
+        end
     end
     T_factorization = factorize(T)
 

--- a/test/check.jl
+++ b/test/check.jl
@@ -100,9 +100,9 @@ end
     @test_logs (
         :warn,
         """
-For coefficient (i=2, j=3) with column colors (ci=3, cj=1):
-- In color ci=3, columns [2, 4] all have nonzeros in row j=3.
-- In color cj=1, columns [1, 3, 5, 6] all have nonzeros in row i=2.
+For coefficient (i=2, j=3) with colors (ci=3, cj=1):
+- In row color ci=3, rows [2, 4] all have nonzeros in column j=3.
+- In column color cj=1, columns [1, 3, 5, 6] all have nonzeros in row i=2.
 """,
     ) symmetrically_orthogonal_columns(A, [1, 3, 1, 3, 1, 1]; verbose=true)
 
@@ -151,9 +151,36 @@ end
     @test_logs (
         :warn,
         """
-For coefficient (i=1, j=1) with row color ci=1 and column color cj=1:
+For coefficient (i=1, j=1) with colors (ci=1, cj=1):
 - In row color ci=1, rows [1, 2, 3] all have nonzeros in column j=1.
 - In column color cj=1, columns [1, 2, 3, 4] all have nonzeros in row i=1.
 """,
     ) !structurally_biorthogonal(A, [1, 1, 1, 2], [1, 1, 1, 1, 2]; verbose=true)
+
+    @test_logs (
+        :warn,
+        """
+For coefficient (i=1, j=2) with colors (ci=0, cj=2):
+- Row color ci=0 is neutral.
+- In column color cj=2, columns [2, 3, 4] all have nonzeros in row i=1.
+""",
+    ) structurally_biorthogonal(A, [0, 2, 2, 3], [1, 2, 2, 2, 3], verbose=true)
+
+    @test_logs (
+        :warn,
+        """
+For coefficient (i=2, j=1) with colors (ci=2, cj=0):
+- In row color ci=2, rows [2, 3] all have nonzeros in column j=1.
+- Column color cj=0 is neutral.
+""",
+    ) structurally_biorthogonal(A, [1, 2, 2, 3], [0, 2, 2, 2, 3], verbose=true)
+
+    @test_logs (
+        :warn,
+        """
+For coefficient (i=1, j=1) with colors (ci=0, cj=0):
+- Row color ci=0 is neutral.
+- Column color cj=0 is neutral.
+""",
+    ) structurally_biorthogonal(A, [0, 2, 2, 3], [0, 2, 2, 2, 3], verbose=true)
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -71,7 +71,9 @@ end;
 
 @testset "Bicoloring & direct decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
-    algo = GreedyColoringAlgorithm(RandomOrder(rng); decompression=:direct)
+    algo = GreedyColoringAlgorithm(
+        RandomOrder(rng); postprocessing=true, decompression=:direct
+    )
     @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         test_bicoloring_decompression(A0, problem, algo)
@@ -84,7 +86,9 @@ end;
 
 @testset "Bicoloring & substitution decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
-    algo = GreedyColoringAlgorithm(RandomOrder(rng); decompression=:substitution)
+    algo = GreedyColoringAlgorithm(
+        RandomOrder(rng); postprocessing=true, decompression=:substitution
+    )
     @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
         A0 = sprand(rng, m, n, p)
         test_bicoloring_decompression(A0, problem, algo)

--- a/test/random.jl
+++ b/test/random.jl
@@ -51,50 +51,70 @@ end;
 
 @testset "Symmetric coloring & direct decompression" begin
     problem = ColoringProblem(; structure=:symmetric, partition=:column)
-    algo = GreedyColoringAlgorithm(; decompression=:direct)
-    @testset "$((; n, p))" for (n, p) in symmetric_params
-        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
-        color0 = symmetric_coloring(A0, algo)
-        test_coloring_decompression(A0, problem, algo; color0)
+    @testset for algo in (
+        GreedyColoringAlgorithm(; postprocessing=false, decompression=:direct),
+        GreedyColoringAlgorithm(; postprocessing=true, decompression=:direct),
+    )
+        @testset "$((; n, p))" for (n, p) in symmetric_params
+            A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+            color0 = algo.postprocessing ? nothing : symmetric_coloring(A0, algo)
+            test_coloring_decompression(A0, problem, algo; color0)
+        end
     end
 end;
 
 @testset "Symmetric coloring & substitution decompression" begin
     problem = ColoringProblem(; structure=:symmetric, partition=:column)
-    algo = GreedyColoringAlgorithm(; decompression=:substitution)
-    @testset "$((; n, p))" for (n, p) in symmetric_params
-        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
-        # TODO: find tests for recoverability
-        test_coloring_decompression(A0, problem, algo)
+    @testset for algo in (
+        GreedyColoringAlgorithm(; postprocessing=false, decompression=:substitution),
+        GreedyColoringAlgorithm(; postprocessing=true, decompression=:substitution),
+    )
+        @testset "$((; n, p))" for (n, p) in symmetric_params
+            A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+            # TODO: find tests for recoverability
+            test_coloring_decompression(A0, problem, algo)
+        end
     end
 end;
 
 @testset "Bicoloring & direct decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
-    algo = GreedyColoringAlgorithm(
-        RandomOrder(rng); postprocessing=true, decompression=:direct
+    @testset for algo in (
+        GreedyColoringAlgorithm(
+            RandomOrder(rng); postprocessing=false, decompression=:direct
+        ),
+        GreedyColoringAlgorithm(
+            RandomOrder(rng); postprocessing=true, decompression=:direct
+        ),
     )
-    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
-        A0 = sprand(rng, m, n, p)
-        test_bicoloring_decompression(A0, problem, algo)
-    end
-    @testset "$((; n, p))" for (n, p) in symmetric_params
-        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
-        test_bicoloring_decompression(A0, problem, algo)
+        @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
+            A0 = sprand(rng, m, n, p)
+            test_bicoloring_decompression(A0, problem, algo)
+        end
+        @testset "$((; n, p))" for (n, p) in symmetric_params
+            A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+            test_bicoloring_decompression(A0, problem, algo)
+        end
     end
 end;
 
 @testset "Bicoloring & substitution decompression" begin
     problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
-    algo = GreedyColoringAlgorithm(
-        RandomOrder(rng); postprocessing=true, decompression=:substitution
+    @testset for algo in (
+        GreedyColoringAlgorithm(
+            RandomOrder(rng); postprocessing=false, decompression=:substitution
+        ),
+        GreedyColoringAlgorithm(
+            RandomOrder(rng); postprocessing=true, decompression=:substitution
+        ),
     )
-    @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
-        A0 = sprand(rng, m, n, p)
-        test_bicoloring_decompression(A0, problem, algo)
-    end
-    @testset "$((; n, p))" for (n, p) in symmetric_params
-        A0 = sparse(Symmetric(sprand(rng, n, n, p)))
-        test_bicoloring_decompression(A0, problem, algo)
+        @testset "$((; m, n, p))" for (m, n, p) in asymmetric_params
+            A0 = sprand(rng, m, n, p)
+            test_bicoloring_decompression(A0, problem, algo)
+        end
+        @testset "$((; n, p))" for (n, p) in symmetric_params
+            A0 = sparse(Symmetric(sprand(rng, n, n, p)))
+            test_bicoloring_decompression(A0, problem, algo)
+        end
     end
 end;

--- a/test/result.jl
+++ b/test/result.jl
@@ -18,3 +18,16 @@ using Test
         end
     end
 end
+
+@testset "Empty compression" begin
+    A = rand(10, 10)
+    color = zeros(Int, 10)
+    problem = ColoringProblem{:nonsymmetric,:column}()
+    algo = ConstantColoringAlgorithm(A, color; partition=:column)
+    B = compress(A, coloring(A, problem, algo))
+    @test size(B, 2) == 0
+    problem = ColoringProblem{:nonsymmetric,:row}()
+    algo = ConstantColoringAlgorithm(A, color; partition=:row)
+    B = compress(A, coloring(A, problem, algo))
+    @test size(B, 1) == 0
+end

--- a/test/result.jl
+++ b/test/result.jl
@@ -9,5 +9,12 @@ using Test
         @test all(1:maximum(color)) do c
             all(color[group[c]] .== c) && issorted(group[c])
         end
+
+        color = rand(0:cmax, n)
+        group = group_by_color(color)
+        @test length(group) == maximum(color)
+        @test all(1:maximum(color)) do c
+            all(color[group[c]] .== c) && issorted(group[c])
+        end
     end
 end

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -95,7 +95,7 @@ what_table_41_42 = CSV.read(
         @test nb_edges(ag) == row[:E]
         @test maximum_degree(ag) == row[:Δ]
         @test minimum_degree(ag) == row[:δ]
-        color_N, _ = star_coloring(ag, NaturalOrder())
+        color_N, _ = star_coloring(ag, NaturalOrder(); postprocessing=false)
         @test_skip row[:KS1] <= length(unique(color_N)) <= row[:KS2]  # TODO: find better
         yield()
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -86,6 +86,7 @@ function test_coloring_decompression(
                 A2 = respectful_similar(A)
                 A2 .= zero(eltype(A2))
                 for c in unique(color)
+                    c == 0 && continue
                     if partition == :column
                         decompress_single_color!(A2, B[:, c], c, result)
                     elseif partition == :row
@@ -125,6 +126,7 @@ function test_coloring_decompression(
                 A4both .= zero(eltype(A))
 
                 for c in unique(color)
+                    c == 0 && continue
                     decompress_single_color!(A4upper, B[:, c], c, result, :U)
                     decompress_single_color!(A4lower, B[:, c], c, result, :L)
                     decompress_single_color!(A4both, B[:, c], c, result, :F)
@@ -149,6 +151,9 @@ function test_coloring_decompression(
 
     @testset "Coherence between all colorings" begin
         @test all(color_vec .== Ref(color_vec[1]))
+        if !all(color_vec .== Ref(color_vec[1]))
+            @show color_vec
+        end
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -168,8 +168,8 @@ function test_bicoloring_decompression(
         end
         Br, Bc = compress(A, result)
         row_color, column_color = row_colors(result), column_colors(result)
-        @test size(Br, 1) == length(unique(row_color))
-        @test size(Bc, 2) == length(unique(column_color))
+        @test size(Br, 1) == length(unique(row_color[row_color .> 0]))
+        @test size(Bc, 2) == length(unique(column_color[column_color .> 0]))
         @test ncolors(result) == size(Br, 1) + size(Bc, 2)
 
         if decompression == :direct


### PR DESCRIPTION
Fixes #122, fixes #158

**Done**:

- [x] Add a `postprocessing` kwarg to `GreedyColoringAlgorithm` which allows removing useless colors and replacing them with the "neutral" color `0`. This only applies to symmetric or bidirectional colorings.
- [x] Explain postprocessing in the relevant docstrings.
- [x] Implement postprocessing by:
  1. mirroring the decompression code to detect which colors are needed
  2. zero out unneeded colors
  3. renumber colors to get a lower maximum color
- [x] Improve the `StarSet` and `TreeSet` storages:
  -  Clarify the negative hub trick for star coloring, and undo it before building the `StarSet`
  - Move the BFS computation for acyclic coloring from the result constructor to the `TreeSet` constructor, so that it is available for postprocessing
- [x] Modify color grouping to ignore neutral colors, adjust `stack`ing to handle empty color groups
- [x] Adapt tests.
- [x] Adapt visualization.

**To do:**

- [ ] Add tests on small instance with known results (https://github.com/gdalle/SparseMatrixColorings.jl/issues/169)
  - Rectangle
  - Arrowhead