### PR TITLE
Reduce the dynamic allocations in acyclic coloring

### DIFF
--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -302,6 +302,10 @@ function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessin
     first_neighbor = fill((0, 0), nv)  # at first no neighbors have been encountered
     first_visit_to_tree = fill((0, 0), ne)
     forest = DisjointSets{Tuple{Int,Int}}()
+    sizehint!(forest.intmap, ne)
+    sizehint!(forest.revmap, ne)
+    sizehint!(forest.internal.parents, ne)
+    sizehint!(forest.internal.ranks, ne)
     vertices_in_order = vertices(g, order)
 
     for v in vertices_in_order


### PR DESCRIPTION
I wanted to use the function `sizehint!` in `DataStructures.jl` but it's incomplete:
https://github.com/JuliaCollections/DataStructures.jl/blob/master/src/disjoint_set.jl#L182-L186

We should do our own structure for the `forest` one day.