### PR TITLE
Detect stars in the forest for acyclic coloring

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -567,6 +567,7 @@ function decompress!(
         for (i, j) in reverse_bfs_orders[k]
             val = B[i, color[j]] - buffer_right_type[i]
             buffer_right_type[j] = buffer_right_type[j] + val
+
             if in_triangle(i, j, uplo)
                 A[i, j] = val
             end

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -19,7 +19,7 @@ end
 
 @testset "Distance-2 coloring" begin
     test_noallocs_distance2_coloring(1000)
-end;
+end
 
 function test_noallocs_sparse_decompression(
     n::Integer; structure::Symbol, partition::Symbol, decompression::Symbol
@@ -121,7 +121,7 @@ end
     ]
         test_noallocs_sparse_decompression(1000; structure, partition, decompression)
     end
-end;
+end
 
 @testset "Structured decompression" begin
     @testset "$structure - $partition - $decompression" for (
@@ -131,4 +131,4 @@ end;
     ]
         test_noallocs_structured_decompression(1000; structure, partition, decompression)
     end
-end;
+end


### PR DESCRIPTION
close #178, #181
Add a vector of booleans `is_star` to the `TreeSet` so that we can enable more efficient post-processing for acyclic coloring by determining if a tree is a star (trivial or non-trivial).