### PR TITLE
Add an attribute has_loops in AdjacencyGraph

### DIFF
--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -557,7 +557,7 @@ function postprocess!(
     color_used = zeros(Bool, maximum(color))
 
     # nonzero diagonal coefficients force the use of their respective color (there can be no neutral colors if the diagonal is fully nonzero)
-    if has_diagonal(S)
+    if has_diagonal(g)
         for i in axes(S, 1)
             if !iszero(S[i, i])
                 color_used[color[i]] = true

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -552,14 +552,16 @@ function postprocess!(
     star_or_tree_set::Union{StarSet,TreeSet},
     g::AdjacencyGraph,
 )
-    (; S) = g
+    (; S, has_loops) = g
     # flag which colors are actually used during decompression
     color_used = zeros(Bool, maximum(color))
 
     # nonzero diagonal coefficients force the use of their respective color (there can be no neutral colors if the diagonal is fully nonzero)
-    for i in axes(S, 1)
-        if !iszero(S[i, i])
-            color_used[color[i]] = true
+    if has_loops
+        for i in axes(S, 1)
+            if !iszero(S[i, i])
+                color_used[color[i]] = true
+            end
         end
     end
 

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -552,12 +552,12 @@ function postprocess!(
     star_or_tree_set::Union{StarSet,TreeSet},
     g::AdjacencyGraph,
 )
-    (; S, has_loops) = g
+    (; S) = g
     # flag which colors are actually used during decompression
     color_used = zeros(Bool, maximum(color))
 
     # nonzero diagonal coefficients force the use of their respective color (there can be no neutral colors if the diagonal is fully nonzero)
-    if has_loops
+    if has_diagonal(S)
         for i in axes(S, 1)
             if !iszero(S[i, i])
                 color_used[color[i]] = true

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -422,7 +422,7 @@ function decompress!(
     fill!(A, zero(eltype(A)))
 
     # Recover the diagonal coefficients of A
-    if has_diagonal(S)
+    if has_diagonal(ag)
         for i in axes(A, 1)
             if !iszero(S[i, i])
                 A[i, i] = B[i, color[i]]
@@ -459,7 +459,7 @@ function decompress_single_color!(
     uplo == :F && check_same_pattern(A, S)
 
     # Recover the diagonal coefficients of A
-    if has_diagonal(S)
+    if has_diagonal(ag)
         for i in axes(A, 1)
             if !iszero(S[i, i]) && color[i] == c
                 A[i, i] = b[i]
@@ -530,7 +530,7 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    if has_diagonal(S)
+    if has_diagonal(ag)
         for i in axes(A, 1)
             if !iszero(S[i, i])
                 A[i, i] = B[i, color[i]]
@@ -587,7 +587,7 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    if has_diagonal(S)
+    if has_diagonal(ag)
         if uplo == :L
             for i in diagonal_indices
                 # A[i, i] is the first element in column i

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -417,12 +417,12 @@ function decompress!(
 )
     (; ag, color, star_set) = result
     (; star, hub, spokes) = star_set
-    (; S, has_loops) = ag
+    (; S) = ag
     uplo == :F && check_same_pattern(A, S)
     fill!(A, zero(eltype(A)))
 
     # Recover the diagonal coefficients of A
-    if has_loops
+    if has_diagonal(S)
         for i in axes(A, 1)
             if !iszero(S[i, i])
                 A[i, i] = B[i, color[i]]
@@ -455,11 +455,11 @@ function decompress_single_color!(
 )
     (; ag, color, group, star_set) = result
     (; hub, spokes) = star_set
-    (; S, has_loops) = ag
+    (; S) = ag
     uplo == :F && check_same_pattern(A, S)
 
     # Recover the diagonal coefficients of A
-    if has_loops
+    if has_diagonal(S)
         for i in axes(A, 1)
             if !iszero(S[i, i]) && color[i] == c
                 A[i, i] = b[i]
@@ -488,7 +488,7 @@ function decompress!(
     A::SparseMatrixCSC, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
     (; ag, compressed_indices) = result
-    S = ag.S
+    (; S) = ag
     nzA = nonzeros(A)
     if uplo == :F
         check_same_pattern(A, S)
@@ -518,7 +518,7 @@ function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::TreeSetColoringResult, uplo::Symbol=:F
 )
     (; ag, color, vertices_by_tree, reverse_bfs_orders, buffer) = result
-    (; S, has_loops) = ag
+    (; S) = ag
     uplo == :F && check_same_pattern(A, S)
     R = eltype(A)
     fill!(A, zero(R))
@@ -530,7 +530,7 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    if has_loops
+    if has_diagonal(S)
         for i in axes(A, 1)
             if !iszero(S[i, i])
                 A[i, i] = B[i, color[i]]
@@ -575,7 +575,7 @@ function decompress!(
         upper_triangle_offsets,
         buffer,
     ) = result
-    (; S, has_loops) = ag
+    (; S) = ag
     A_colptr = A.colptr
     nzA = nonzeros(A)
     uplo == :F && check_same_pattern(A, S)
@@ -587,7 +587,7 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    if has_loops
+    if has_diagonal(S)
         if uplo == :L
             for i in diagonal_indices
                 # A[i, i] is the first element in column i

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -415,16 +415,22 @@ end
 function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
-    (; color, star_set) = result
+    (; ag, color, star_set) = result
     (; star, hub, spokes) = star_set
-    S = result.ag.S
+    (; S, has_loops) = ag
     uplo == :F && check_same_pattern(A, S)
     fill!(A, zero(eltype(A)))
-    for i in axes(A, 1)
-        if !iszero(S[i, i])
-            A[i, i] = B[i, color[i]]
+
+    # Recover the diagonal coefficients of A
+    if has_loops
+        for i in axes(A, 1)
+            if !iszero(S[i, i])
+                A[i, i] = B[i, color[i]]
+            end
         end
     end
+
+    # Recover the off-diagonal coefficients of A
     for s in eachindex(hub, spokes)
         j = abs(hub[s])
         cj = color[j]
@@ -447,15 +453,21 @@ function decompress_single_color!(
     result::StarSetColoringResult,
     uplo::Symbol=:F,
 )
-    (; color, group, star_set) = result
+    (; ag, color, group, star_set) = result
     (; hub, spokes) = star_set
-    S = result.ag.S
+    (; S, has_loops) = ag
     uplo == :F && check_same_pattern(A, S)
-    for i in axes(A, 1)
-        if !iszero(S[i, i]) && color[i] == c
-            A[i, i] = b[i]
+
+    # Recover the diagonal coefficients of A
+    if has_loops
+        for i in axes(A, 1)
+            if !iszero(S[i, i]) && color[i] == c
+                A[i, i] = b[i]
+            end
         end
     end
+
+    # Recover the off-diagonal coefficients of A
     for s in eachindex(hub, spokes)
         j = abs(hub[s])
         if color[j] == c
@@ -475,8 +487,8 @@ end
 function decompress!(
     A::SparseMatrixCSC, B::AbstractMatrix, result::StarSetColoringResult, uplo::Symbol=:F
 )
-    (; compressed_indices) = result
-    S = result.ag.S
+    (; ag, compressed_indices) = result
+    S = ag.S
     nzA = nonzeros(A)
     if uplo == :F
         check_same_pattern(A, S)
@@ -505,8 +517,8 @@ end
 function decompress!(
     A::AbstractMatrix, B::AbstractMatrix, result::TreeSetColoringResult, uplo::Symbol=:F
 )
-    (; color, vertices_by_tree, reverse_bfs_orders, buffer) = result
-    S = result.ag.S
+    (; ag, color, vertices_by_tree, reverse_bfs_orders, buffer) = result
+    (; S, has_loops) = ag
     uplo == :F && check_same_pattern(A, S)
     R = eltype(A)
     fill!(A, zero(R))
@@ -518,9 +530,11 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    for i in axes(A, 1)
-        if !iszero(S[i, i])
-            A[i, i] = B[i, color[i]]
+    if has_loops
+        for i in axes(A, 1)
+            if !iszero(S[i, i])
+                A[i, i] = B[i, color[i]]
+            end
         end
     end
 
@@ -551,6 +565,7 @@ function decompress!(
     uplo::Symbol=:F,
 ) where {R<:Real}
     (;
+        ag,
         color,
         vertices_by_tree,
         reverse_bfs_orders,
@@ -560,7 +575,7 @@ function decompress!(
         upper_triangle_offsets,
         buffer,
     ) = result
-    S = result.ag.S
+    (; S, has_loops) = ag
     A_colptr = A.colptr
     nzA = nonzeros(A)
     uplo == :F && check_same_pattern(A, S)
@@ -572,22 +587,24 @@ function decompress!(
     end
 
     # Recover the diagonal coefficients of A
-    if uplo == :L
-        for i in diagonal_indices
-            # A[i, i] is the first element in column i
-            nzind = A_colptr[i]
-            nzA[nzind] = B[i, color[i]]
-        end
-    elseif uplo == :U
-        for i in diagonal_indices
-            # A[i, i] is the last element in column i
-            nzind = A_colptr[i + 1] - 1
-            nzA[nzind] = B[i, color[i]]
-        end
-    else  # uplo == :F
-        for (k, i) in enumerate(diagonal_indices)
-            nzind = diagonal_nzind[k]
-            nzA[nzind] = B[i, color[i]]
+    if has_loops
+        if uplo == :L
+            for i in diagonal_indices
+                # A[i, i] is the first element in column i
+                nzind = A_colptr[i]
+                nzA[nzind] = B[i, color[i]]
+            end
+        elseif uplo == :U
+            for i in diagonal_indices
+                # A[i, i] is the last element in column i
+                nzind = A_colptr[i + 1] - 1
+                nzA[nzind] = B[i, color[i]]
+            end
+        else  # uplo == :F
+            for (k, i) in enumerate(diagonal_indices)
+                nzind = diagonal_nzind[k]
+                nzA[nzind] = B[i, color[i]]
+            end
         end
     end
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -121,10 +121,17 @@ struct AdjacencyGraph{T,has_diagonal}
     S::SparsityPatternCSC{T}
 end
 
-AdjacencyGraph(S::SparsityPatternCSC) = AdjacencyGraph{typeof(S),true}(S)
+function AdjacencyGraph(S::SparsityPatternCSC{T}; has_diagonal::Bool=true) where {T}
+    return AdjacencyGraph{T,has_diagonal}(S)
+end
 
-AdjacencyGraph(A::AbstractMatrix) = AdjacencyGraph(SparseMatrixCSC(A))
-AdjacencyGraph(A::SparseMatrixCSC) = AdjacencyGraph(SparsityPatternCSC(A))
+function AdjacencyGraph(A::SparseMatrixCSC; has_diagonal::Bool=true)
+    return AdjacencyGraph(SparsityPatternCSC(A); has_diagonal)
+end
+
+function AdjacencyGraph(A::AbstractMatrix; has_diagonal::Bool=true)
+    return AdjacencyGraph(SparseMatrixCSC(A); has_diagonal)
+end
 
 pattern(g::AdjacencyGraph) = g.S
 nb_vertices(g::AdjacencyGraph) = pattern(g).n

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -96,7 +96,7 @@ end
 ## Adjacency graph
 
 """
-    AdjacencyGraph{T}
+    AdjacencyGraph{T,has_diagonal}
 
 Undirected graph without self-loops representing the nonzeros of a symmetric matrix (typically a Hessian matrix).
 
@@ -111,49 +111,37 @@ The adjacency graph of a symmetric matrix `A ∈ ℝ^{n × n}` is `G(A) = (V, E)
 
 # Fields
 
-- `S::SparsityPatternCSC{T}`
+- `S::SparsityPatternCSC{T}`: Underlying sparsity pattern, whose diagonal is empty whenever `has_diagonal` is `false`
 
 # References
 
 > [_What Color Is Your Jacobian? SparsityPatternCSC Coloring for Computing Derivatives_](https://epubs.siam.org/doi/10.1137/S0036144504444711), Gebremedhin et al. (2005)
 """
-struct AdjacencyGraph{T}
+struct AdjacencyGraph{T,has_diagonal}
     S::SparsityPatternCSC{T}
-    has_loops::Bool
 end
 
-function check_loops(A::AbstractMatrix)
-    n = size(A, 1)
-    has_loops = false
-    i = 1
-    while !has_loops && i <= n
-        if !iszero(A[i, i])
-            has_loops = true
-        else
-            i += 1
-        end
-    end
-    return has_loops
-end
+AdjacencyGraph(S::SparsityPatternCSC) = AdjacencyGraph{typeof(S),true}(S)
 
-AdjacencyGraph(A::AbstractMatrix) = AdjacencyGraph(SparseMatrixCSC(A), check_loops(A))
-AdjacencyGraph(A::SparseMatrixCSC) = AdjacencyGraph(SparsityPatternCSC(A), check_loops(A))
-function AdjacencyGraph(A::SparseMatrixCSC, has_loops::Bool)
-    return AdjacencyGraph(SparsityPatternCSC(A), has_loops)
-end
+AdjacencyGraph(A::AbstractMatrix) = AdjacencyGraph(SparseMatrixCSC(A))
+AdjacencyGraph(A::SparseMatrixCSC) = AdjacencyGraph(SparsityPatternCSC(A))
 
 pattern(g::AdjacencyGraph) = g.S
 nb_vertices(g::AdjacencyGraph) = pattern(g).n
 vertices(g::AdjacencyGraph) = 1:nb_vertices(g)
 
-function neighbors(g::AdjacencyGraph, v::Integer)
+has_diagonal(::AdjacencyGraph{T,hl}) where {T,hl} = hl
+
+function neighbors(g::AdjacencyGraph{T,true}, v::Integer) where {T}
     S = pattern(g)
     neighbors_v = view(rowvals(S), nzrange(S, v))
-    if g.has_loops
-        return Iterators.filter(!=(v), neighbors_v)  # TODO: optimize
-    else
-        return neighbors_v
-    end
+    return Iterators.filter(!=(v), neighbors_v)  # TODO: optimize
+end
+
+function neighbors(g::AdjacencyGraph{T,false}, v::Integer) where {T}
+    S = pattern(g)
+    neighbors_v = view(rowvals(S), nzrange(S, v))
+    return neighbors_v
 end
 
 function degree(g::AdjacencyGraph, v::Integer)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -245,7 +245,9 @@ function coloring(
         spzeros(T, n, n) SparseMatrixCSC(Aᵀ)
         SparseMatrixCSC(A) spzeros(T, m, m)
     ]  # TODO: slow
-    ag = AdjacencyGraph(A_and_Aᵀ)
+    has_loops = false
+    ag = AdjacencyGraph(A_and_Aᵀ, has_loops)
+
     if decompression == :direct
         color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)
         symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -245,7 +245,7 @@ function coloring(
         spzeros(T, n, n) SparseMatrixCSC(Aᵀ)
         SparseMatrixCSC(A) spzeros(T, m, m)
     ]  # TODO: slow
-    ag = AdjacencyGraph{typeof(A_and_Aᵀ),false}(A_and_Aᵀ)
+    ag = AdjacencyGraph(A_and_Aᵀ; has_diagonal=false)
     if decompression == :direct
         color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)
         symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -245,9 +245,7 @@ function coloring(
         spzeros(T, n, n) SparseMatrixCSC(Aᵀ)
         SparseMatrixCSC(A) spzeros(T, m, m)
     ]  # TODO: slow
-    has_loops = false
-    ag = AdjacencyGraph(A_and_Aᵀ, has_loops)
-
+    ag = AdjacencyGraph{typeof(A_and_Aᵀ),false}(A_and_Aᵀ)
     if decompression == :direct
         color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)
         symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)

--- a/src/result.jl
+++ b/src/result.jl
@@ -295,23 +295,25 @@ function TreeSetColoringResult(
     decompression_eltype::Type{R},
 ) where {R}
     (; vertices_by_tree, reverse_bfs_orders) = tree_set
-    S = ag.S
+    (; S, has_loops) = ag
     nvertices = length(color)
     group = group_by_color(color)
+    rv = rowvals(S)
 
     # Vector for the decompression of the diagonal coefficients
     diagonal_indices = Int[]
     diagonal_nzind = Int[]
     ndiag = 0
 
-    rv = rowvals(S)
-    for j in axes(S, 2)
-        for k in nzrange(S, j)
-            i = rv[k]
-            if i == j
-                push!(diagonal_indices, i)
-                push!(diagonal_nzind, k)
-                ndiag += 1
+    if has_loops
+        for j in axes(S, 2)
+            for k in nzrange(S, j)
+                i = rv[k]
+                if i == j
+                    push!(diagonal_indices, i)
+                    push!(diagonal_nzind, k)
+                    ndiag += 1
+                end
             end
         end
     end
@@ -497,7 +499,7 @@ struct BicoloringResult{
 } <: AbstractColoringResult{:nonsymmetric,:bidirectional,decompression}
     "matrix that was colored"
     A::M
-    "adjacency graph that was used for coloring (constructed from the bipartite graph)"
+    "augmented adjacency graph that was used for bicoloring"
     abg::G
     "one integer color for each column"
     column_color::Vector{Int}
@@ -507,7 +509,7 @@ struct BicoloringResult{
     column_group::V
     "color groups for rows"
     row_group::V
-    "result for the coloring of the symmetric 2x2 block matrix"
+    "result for the coloring of the symmetric 2 x 2 block matrix"
     symmetric_result::SR
     "column color to index"
     col_color_ind::Dict{Int,Int}

--- a/src/result.jl
+++ b/src/result.jl
@@ -305,7 +305,7 @@ function TreeSetColoringResult(
     diagonal_nzind = Int[]
     ndiag = 0
 
-    if has_diagonal(S)
+    if has_diagonal(ag)
         for j in axes(S, 2)
             for k in nzrange(S, j)
                 i = rv[k]

--- a/src/result.jl
+++ b/src/result.jl
@@ -295,7 +295,7 @@ function TreeSetColoringResult(
     decompression_eltype::Type{R},
 ) where {R}
     (; vertices_by_tree, reverse_bfs_orders) = tree_set
-    (; S, has_loops) = ag
+    (; S) = ag
     nvertices = length(color)
     group = group_by_color(color)
     rv = rowvals(S)
@@ -305,7 +305,7 @@ function TreeSetColoringResult(
     diagonal_nzind = Int[]
     ndiag = 0
 
-    if has_loops
+    if has_diagonal(S)
         for j in axes(S, 2)
             for k in nzrange(S, j)
                 i = rv[k]


### PR DESCRIPTION
close #182
Take into account that the diagonal is zero in bicoloring and could be zero in symmetric colorings for a faster postprocessing, decompression and construction of the `TreeSetColoringResult`.