### PR TITLE
Optimize remap_colors

### DIFF
--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -648,9 +648,9 @@ function postprocess!(
         num_colors_useless = 0
 
         # determine what are the useless colors and compute the offsets
-        for i in 1:nb_colors
-            if color_used[i]
-                offsets[i] = num_colors_useless
+        for ci in 1:nb_colors
+            if color_used[ci]
+                offsets[ci] = num_colors_useless
             else
                 num_colors_useless += 1
             end

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -659,7 +659,7 @@ function postprocess!(
         # assign the neutral color to every vertex with a useless color and remap the colors
         for i in eachindex(color)
             ci = color[i]
-            !color_used[ci]
+            if !color_used[ci]
                 # assign the neutral color
                 color[i] = 0
             else

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -653,14 +653,13 @@ function postprocess!(
                 offsets[i] = num_colors_useless
             else
                 num_colors_useless += 1
-                offsets[i] = -num_colors_useless
             end
         end
 
         # assign the neutral color to every vertex with a useless color and remap the colors
         for i in eachindex(color)
             ci = color[i]
-            if offsets[ci] < 0
+            !color_used[ci]
                 # assign the neutral color
                 color[i] = 0
             else


### PR DESCRIPTION
close #172 
- Avoid the call to remap_colors in postprocess!
- Optimize `remap_colors`
- Use two vectors of integer `symmetric_to_column` and `symmetric_to_row` for the mapping between symmetric colors and row / column colors