### PR TITLE
Remove some dictionaries in star and acyclic coloring

### DIFF
--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -39,7 +39,8 @@ using SparseArrays:
     nzrange,
     rowvals,
     sparse,
-    spzeros
+    spzeros,
+    triu
 
 include("graph.jl")
 include("forest.jl")

--- a/src/forest.jl
+++ b/src/forest.jl
@@ -10,12 +10,8 @@ Structure that provides fast union-find operations for constructing a forest dur
 $TYPEDFIELDS
 """
 mutable struct Forest{T<:Integer}
-    "current number of edges in the forest"
-    num_edges::T
     "current number of distinct trees in the forest"
     num_trees::T
-    "dictionary mapping each edge represented as a tuple of vertices to its unique integer index"
-    intmap::Dict{Tuple{T,T},T}
     "vector storing the index of a parent in the tree for each edge, used in union-find operations"
     parents::Vector{T}
     "vector approximating the depth of each tree to optimize path compression"
@@ -23,20 +19,10 @@ mutable struct Forest{T<:Integer}
 end
 
 function Forest{T}(n::Integer) where {T<:Integer}
-    num_edges = zero(T)
-    num_trees = zero(T)
-    intmap = Dict{Tuple{T,T},T}()
-    sizehint!(intmap, n)
+    num_trees = T(n)
     parents = collect(Base.OneTo(T(n)))
     ranks = zeros(T, T(n))
-    return Forest{T}(num_edges, num_trees, intmap, parents, ranks)
-end
-
-function Base.push!(forest::Forest{T}, edge::Tuple{T,T}) where {T<:Integer}
-    forest.num_edges += 1
-    forest.intmap[edge] = forest.num_edges
-    forest.num_trees += one(T)
-    return forest
+    return Forest{T}(num_trees, parents, ranks)
 end
 
 function _find_root!(parents::Vector{T}, index_edge::T) where {T<:Integer}
@@ -47,8 +33,8 @@ function _find_root!(parents::Vector{T}, index_edge::T) where {T<:Integer}
     return p
 end
 
-function find_root!(forest::Forest{T}, edge::Tuple{T,T}) where {T<:Integer}
-    return _find_root!(forest.parents, forest.intmap[edge])
+function find_root!(forest::Forest{T}, index_edge::T) where {T<:Integer}
+    return _find_root!(forest.parents, index_edge)
 end
 
 function root_union!(forest::Forest{T}, index_edge1::T, index_edge2::T) where {T<:Integer}

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -189,14 +189,23 @@ The adjacency graph of a symmetric matrix `A ∈ ℝ^{n × n}` is `G(A) = (V, E)
 """
 struct AdjacencyGraph{T,has_diagonal}
     S::SparsityPatternCSC{T}
+    M::SparseMatrixCSC{T,T}
 end
 
-function AdjacencyGraph(S::SparsityPatternCSC{T}; has_diagonal::Bool=true) where {T}
-    return AdjacencyGraph{T,has_diagonal}(S)
+function AdjacencyGraph(
+    S::SparsityPatternCSC{T}, M::SparseMatrixCSC{T,T}; has_diagonal::Bool=true
+) where {T}
+    return AdjacencyGraph{T,has_diagonal}(S, M)
 end
 
 function AdjacencyGraph(A::SparseMatrixCSC; has_diagonal::Bool=true)
-    return AdjacencyGraph(SparsityPatternCSC(A); has_diagonal)
+    S = SparsityPatternCSC(A)
+    M = triu(A, 1)
+    nnzM = Int(nnz(M))
+    nzval = collect(Base.OneTo(nnzM))
+    m, n = size(A)
+    M = SparseMatrixCSC(m, n, M.colptr, M.rowval, nzval)
+    return AdjacencyGraph(S, M; has_diagonal)
 end
 
 function AdjacencyGraph(A::AbstractMatrix; has_diagonal::Bool=true)

--- a/test/forest.jl
+++ b/test/forest.jl
@@ -3,74 +3,36 @@ using Test
 
 @testset "Constructor Forest" begin
     forest = Forest{Int}(5)
-
-    @test forest.num_edges == 0
-    @test forest.num_trees == 0
-    @test length(forest.intmap) == 0
+    @test forest.num_trees == 5
     @test length(forest.parents) == 5
     @test all(forest.parents .== 1:5)
     @test all(forest.ranks .== 0)
 end
 
-@testset "Push edge" begin
+@testset "Root union -- find root" begin
     forest = Forest{Int}(5)
+    @test forest.num_trees == 5
 
-    push!(forest, (1, 2))
-    @test forest.num_edges == 1
-    @test forest.num_trees == 1
-    @test haskey(forest.intmap, (1, 2))
-    @test forest.intmap[(1, 2)] == 1
-    @test forest.num_trees == 1
-
-    push!(forest, (3, 4))
-    @test forest.num_edges == 2
-    @test forest.num_trees == 2
-    @test haskey(forest.intmap, (3, 4))
-    @test forest.intmap[(3, 4)] == 2
-    @test forest.num_trees == 2
-end
-
-@testset "Find root" begin
-    forest = Forest{Int}(5)
-    push!(forest, (1, 2))
-    push!(forest, (3, 4))
-
-    @test find_root!(forest, (1, 2)) == 1
-    @test find_root!(forest, (3, 4)) == 2
-end
-
-@testset "Root union" begin
-    forest = Forest{Int}(5)
-    push!(forest, (1, 2))
-    push!(forest, (4, 5))
-    push!(forest, (2, 4))
-    @test forest.num_trees == 3
-
-    root1 = find_root!(forest, (1, 2))
-    root3 = find_root!(forest, (2, 4))
+    root1 = find_root!(forest, 1)
+    root3 = find_root!(forest, 3)
     @test root1 != root3
 
     root_union!(forest, root1, root3)
-    @test find_root!(forest, (2, 4)) == 1
+    @test find_root!(forest, 3) == 1
     @test forest.parents[1] == 1
     @test forest.parents[3] == 1
     @test forest.ranks[1] == 1
     @test forest.ranks[3] == 0
-    @test forest.num_trees == 2
+    @test forest.num_trees == 4
 
-    root1 = find_root!(forest, (1, 2))
-    root2 = find_root!(forest, (4, 5))
+    root1 = find_root!(forest, 1)
+    root2 = find_root!(forest, 2)
     @test root1 != root2
     root_union!(forest, root1, root2)
-    @test find_root!(forest, (4, 5)) == 1
+    @test find_root!(forest, 2) == 1
     @test forest.parents[1] == 1
     @test forest.parents[2] == 1
     @test forest.ranks[1] == 1
     @test forest.ranks[2] == 0
-    @test forest.num_trees == 1
-
-    push!(forest, (1, 4))
-    @test forest.num_trees == 2
-    @test forest.intmap[(1, 4)] == 4
-    @test forest.parents[4] == 4
+    @test forest.num_trees == 3
 end


### PR DESCRIPTION
Quick test to see how much we gain with a dictionary.
Finding the index of an edge before this PR was `O(1)`, now it is `O(log(n))`.
It can also be `O(1) without a dictionary but it requires more modifications and I would like to know what is the gap already.