### PR TITLE
Add a default value for postprocessing

### DIFF
--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -294,7 +294,9 @@ If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" 
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 3.1
 """
-function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
+function acyclic_coloring(
+    g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false
+)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -54,7 +54,7 @@ function partial_distance2_coloring!(
 end
 
 """
-    star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool)
+    star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
 
 Compute a star coloring of all vertices in the adjacency graph `g` and return a tuple `(color, star_set)`, where
 
@@ -76,7 +76,7 @@ If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" 
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 4.1
 """
-function star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool)
+function star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)
@@ -272,7 +272,7 @@ function symmetric_coefficient(
 end
 
 """
-    acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool)
+    acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
 
 Compute an acyclic coloring of all vertices in the adjacency graph `g` and return a tuple `(color, tree_set)`, where
 
@@ -294,7 +294,7 @@ If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" 
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 3.1
 """
-function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool)
+function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)

--- a/src/coloring.jl
+++ b/src/coloring.jl
@@ -54,7 +54,7 @@ function partial_distance2_coloring!(
 end
 
 """
-    star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
+    star_coloring(g::AdjacencyGraph, order::AbstractOrder, postprocessing::Bool)
 
 Compute a star coloring of all vertices in the adjacency graph `g` and return a tuple `(color, star_set)`, where
 
@@ -76,7 +76,7 @@ If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" 
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 4.1
 """
-function star_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
+function star_coloring(g::AdjacencyGraph, order::AbstractOrder, postprocessing::Bool)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)
@@ -272,7 +272,7 @@ function symmetric_coefficient(
 end
 
 """
-    acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false)
+    acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder, postprocessing::Bool)
 
 Compute an acyclic coloring of all vertices in the adjacency graph `g` and return a tuple `(color, tree_set)`, where
 
@@ -294,9 +294,7 @@ If `postprocessing=true`, some colors might be replaced with `0` (the "neutral" 
 
 > [_New Acyclic and Star Coloring Algorithms with Application to Computing Hessians_](https://epubs.siam.org/doi/abs/10.1137/050639879), Gebremedhin et al. (2007), Algorithm 3.1
 """
-function acyclic_coloring(
-    g::AdjacencyGraph, order::AbstractOrder; postprocessing::Bool=false
-)
+function acyclic_coloring(g::AdjacencyGraph, order::AbstractOrder, postprocessing::Bool)
     # Initialize data structures
     nv = nb_vertices(g)
     ne = nb_edges(g)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -266,7 +266,7 @@ function _coloring(
     symmetric_pattern::Bool,
 )
     ag = AdjacencyGraph(A)
-    color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)
+    color, star_set = star_coloring(ag, algo.order, algo.postprocessing)
     if speed_setting isa WithResult
         return StarSetColoringResult(A, ag, color, star_set)
     else
@@ -283,7 +283,7 @@ function _coloring(
     symmetric_pattern::Bool,
 ) where {R}
     ag = AdjacencyGraph(A)
-    color, tree_set = acyclic_coloring(ag, algo.order; postprocessing=algo.postprocessing)
+    color, tree_set = acyclic_coloring(ag, algo.order, algo.postprocessing)
     if speed_setting isa WithResult
         return TreeSetColoringResult(A, ag, color, tree_set, R)
     else
@@ -301,7 +301,7 @@ function _coloring(
 ) where {R}
     A_and_Aᵀ = bidirectional_pattern(A; symmetric_pattern)
     ag = AdjacencyGraph(A_and_Aᵀ; has_diagonal=false)
-    color, star_set = star_coloring(ag, algo.order; postprocessing=algo.postprocessing)
+    color, star_set = star_coloring(ag, algo.order, algo.postprocessing)
     if speed_setting isa WithResult
         symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)
         return BicoloringResult(A, ag, symmetric_result, R)
@@ -321,7 +321,7 @@ function _coloring(
 ) where {R}
     A_and_Aᵀ = bidirectional_pattern(A; symmetric_pattern)
     ag = AdjacencyGraph(A_and_Aᵀ; has_diagonal=false)
-    color, tree_set = acyclic_coloring(ag, algo.order; postprocessing=algo.postprocessing)
+    color, tree_set = acyclic_coloring(ag, algo.order, algo.postprocessing)
     if speed_setting isa WithResult
         symmetric_result = TreeSetColoringResult(A_and_Aᵀ, ag, color, tree_set, R)
         return BicoloringResult(A, ag, symmetric_result, R)

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -95,7 +95,8 @@ what_table_41_42 = CSV.read(
         @test nb_edges(ag) == row[:E]
         @test maximum_degree(ag) == row[:Δ]
         @test minimum_degree(ag) == row[:δ]
-        color_N, _ = star_coloring(ag, NaturalOrder(); postprocessing=false)
+        postprocessing = false
+        color_N, _ = star_coloring(ag, NaturalOrder(), postprocessing)
         @test_skip row[:KS1] <= length(unique(color_N)) <= row[:KS2]  # TODO: find better
         yield()
     end


### PR DESCRIPTION
I checked something a few days with `@code_warntype` and I found that the compiler generated a very complex code to handle the lack of default value for the keyword argument.

It could also be an argument.