### PR TITLE
Speed up LargestFirst order

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -270,13 +270,9 @@ end
 degree(g::AdjacencyGraph{T,false}, v::Integer) where {T} = g.S.colptr[v + 1] - g.S.colptr[v]
 
 function degree(g::AdjacencyGraph{T,true}, v::Integer) where {T}
-    d = 0
-    for u in neighbors(g, v)
-        if u != v
-            d += 1
-        end
-    end
-    return d
+    neigh = neighbors(g, v)
+    has_selfloop = insorted(v, neigh)
+    return g.S.colptr[v + 1] - g.S.colptr[v] - has_selfloop
 end
 
 nb_edges(g::AdjacencyGraph{T,false}) where {T} = nnz(g.S) ÷ 2

--- a/src/order.jl
+++ b/src/order.jl
@@ -80,7 +80,8 @@ Instance of [`AbstractOrder`](@ref) which sorts vertices using their degree in t
 struct LargestFirst <: AbstractOrder end
 
 function vertices(g::AdjacencyGraph, ::LargestFirst)
-    criterion(v) = degree(g, v)
+    degrees = map(Base.Fix1(degree, g), vertices(g))
+    criterion(v) = degrees[v]
     return sort(vertices(g); by=criterion, rev=true)
 end
 

--- a/src/order.jl
+++ b/src/order.jl
@@ -369,7 +369,7 @@ function vertices(
     for v in vertices(g, Val(side))
         for w1 in neighbors(g, Val(side), v)
             for w2 in neighbors(g, Val(other_side), w1)
-                if w != v && !visited[w]
+                if w2 != v && !visited[w2]
                     degrees_dist2[v] += 1
                     visited[w2] = true
                 end

--- a/test/order.jl
+++ b/test/order.jl
@@ -63,12 +63,13 @@ end;
 @testset "LargestFirst" begin
     for has_diagonal in (false, true)
         A = sparse([
-            0 1 0
-            1 0 1
-            0 1 0
+            0 1 0 0
+            1 0 1 1
+            0 1 0 1
+            0 1 1 0
         ])
         ag = AdjacencyGraph(A; has_diagonal)
-        @test vertices(ag, LargestFirst()) == [2, 1, 3]
+        @test vertices(ag, LargestFirst()) == [2, 3, 4, 1]
     end
 
     A = sparse([


### PR DESCRIPTION
- Speed up degree computation in adjacency graphs with a diagonal
- Compute the degree of each vertex once and store it before sorting
- Avoid `fill!(visited, false)` in other places when only some coefficients have been set to `true`