### PR TITLE
Add precompilation workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "SparseMatrixColorings"
 uuid = "0a514795-09f3-496d-8182-132a7b665d35"
 authors = ["Guillaume Dalle", "Alexis Montoison"]
-version = "0.4.19"
+version = "0.4.20"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -24,6 +25,7 @@ CliqueTrees = "1"
 Colors = "0.12.11, 0.13"
 DocStringExtensions = "0.8,0.9"
 LinearAlgebra = "<0.0.1, 1"
+PrecompileTools = "1.2.1"
 Random = "<0.0.1, 1"
 SparseArrays = "<0.0.1, 1"
 julia = "1.10"

--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -27,6 +27,7 @@ using LinearAlgebra:
     ldiv!,
     parent,
     transpose
+using PrecompileTools: @compile_workload
 using Random: Random, AbstractRNG, default_rng, randperm
 using SparseArrays:
     SparseArrays,
@@ -39,6 +40,7 @@ using SparseArrays:
     nzrange,
     rowvals,
     sparse,
+    sprand,
     spzeros
 
 include("graph.jl")
@@ -54,6 +56,8 @@ include("decompression.jl")
 include("check.jl")
 include("examples.jl")
 include("show_colors.jl")
+
+include("precompile.jl")
 
 export NaturalOrder, RandomOrder, LargestFirst
 export DynamicDegreeBasedOrder, SmallestLast, IncidenceDegree, DynamicLargestFirst

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,7 +6,7 @@ for (structure, partition, decompression) in [
     (:nonsymmetric, :bidirectional, :direct),
     (:nonsymmetric, :bidirectional, :substitution),
 ]
-    A = sparse([1 0; 0 1])
+    A = sparse(Bool[1 0; 0 1])
     problem = ColoringProblem(; structure, partition)
     algo = GreedyColoringAlgorithm(; decompression, postprocessing=true)
     result = coloring(A, problem, algo)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,20 @@
+for (structure, partition, decompression) in [
+    (:nonsymmetric, :column, :direct),
+    (:nonsymmetric, :row, :direct),
+    (:symmetric, :column, :direct),
+    (:symmetric, :column, :substitution),
+    (:nonsymmetric, :bidirectional, :direct),
+    (:nonsymmetric, :bidirectional, :substitution),
+]
+    A = sparse(Symmetric(sprand(Bool, 100, 100, 0.1)))
+    problem = ColoringProblem(; structure, partition)
+    algo = GreedyColoringAlgorithm(; decompression, postprocessing=true)
+    result = coloring(A, problem, algo)
+    if partition == :bidirectional
+        Br, Bc = compress(A, result)
+        decompress(Br, Bc, result)
+    else
+        B = compress(A, result)
+        decompress(B, result)
+    end
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,7 +6,7 @@ for (structure, partition, decompression) in [
     (:nonsymmetric, :bidirectional, :direct),
     (:nonsymmetric, :bidirectional, :substitution),
 ]
-    A = sparse(Symmetric(sprand(Bool, 100, 100, 0.1)))
+    A = sparse([1 0; 0 1])
     problem = ColoringProblem(; structure, partition)
     algo = GreedyColoringAlgorithm(; decompression, postprocessing=true)
     result = coloring(A, problem, algo)


### PR DESCRIPTION
This speeds up time-to-first-plot tremendously.

Benchmark (to run in a fresh Julia session):

```julia
using LinearAlgebra, Random, SparseArrays
using SparseMatrixColorings

# simple task
@time begin
    A = sprand(MersenneTwister(0), Bool, 10, 10, 0.2)
    problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
    algo = GreedyColoringAlgorithm(; decompression=:direct)
    result = coloring(A, problem, algo)
    B = compress(A, result)
    decompress(B, result)
end;

# complicated task
@time begin
    A = sprand(MersenneTwister(0), Bool, 10, 10, 0.2)
    problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
    algo = GreedyColoringAlgorithm(; decompression=:substitution, postprocessing=true)
    result = coloring(A, problem, algo)
    Br, Bc = compress(A, result)
    decompress(Br, Bc, result)
end;
```

With precompilation:

- Simple task: `0.000096 seconds (108 allocations: 26.328 KiB)`
- Complicated task: `0.003747 seconds (1.81 k allocations: 112.008 KiB, 98.13% compilation time)`

Without precompilation:

- Simple task: `0.394682 seconds (2.78 M allocations: 141.290 MiB, 1.76% gc time, 99.95% compilation time)`
- Complicated task: `0.896819 seconds (3.00 M allocations: 154.698 MiB, 1.33% gc time, 99.98% compilation time)`