### PR TITLE
ensure `UnsupportedDecompressionError <: Exception`

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -106,7 +106,7 @@ function compress(
     return Br, Bc
 end
 
-struct UnsupportedDecompressionError
+struct UnsupportedDecompressionError <: Exception
     msg::String
 end
 


### PR DESCRIPTION
Don't know if there is any benefit, but I suppose the intention is for this type, as an exception type, to subtype `Exception`.