### PR TITLE
Make any coloring algorithm compatible with SMC

### DIFF
--- a/src/adtypes.jl
+++ b/src/adtypes.jl
@@ -1,21 +1,32 @@
-function coloring(
-    A::AbstractMatrix,
-    ::ColoringProblem{:nonsymmetric,:column},
-    algo::ADTypes.NoColoringAlgorithm;
-    kwargs...,
-)
-    bg = BipartiteGraph(A)
-    color = convert(Vector{eltype(bg)}, ADTypes.column_coloring(A, algo))
-    return ColumnColoringResult(A, bg, color)
-end
+## From ADTypes to SMC
 
 function coloring(
     A::AbstractMatrix,
-    ::ColoringProblem{:nonsymmetric,:row},
-    algo::ADTypes.NoColoringAlgorithm;
-    kwargs...,
-)
-    bg = BipartiteGraph(A)
-    color = convert(Vector{eltype(bg)}, ADTypes.row_coloring(A, algo))
-    return RowColoringResult(A, bg, color)
+    problem::ColoringProblem{structure,partition},
+    algo::ADTypes.AbstractColoringAlgorithm;
+    decompression_eltype::Type{R}=Float64,
+    symmetric_pattern::Bool=false,
+) where {structure,partition,R}
+    symmetric_pattern = symmetric_pattern || A isa Union{Symmetric,Hermitian}
+    if structure == :nonsymmetric
+        if partition == :column
+            forced_colors = ADTypes.column_coloring(A, algo)
+        elseif partition == :row
+            forced_colors = ADTypes.row_coloring(A, algo)
+        else
+            A_and_Aᵀ, _ = bidirectional_pattern(A; symmetric_pattern)
+            forced_colors = ADTypes.symmetric_coloring(A_and_Aᵀ, algo)
+        end
+    else
+        forced_colors = ADTypes.symmetric_coloring(A, algo)
+    end
+    return _coloring(
+        WithResult(),
+        A,
+        problem,
+        GreedyColoringAlgorithm(),
+        R,
+        symmetric_pattern;
+        forced_colors,
+    )
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -225,12 +225,13 @@ function _coloring(
     ::ColoringProblem{:nonsymmetric,:column},
     algo::GreedyColoringAlgorithm,
     decompression_eltype::Type,
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 )
     symmetric_pattern = symmetric_pattern || A isa Union{Symmetric,Hermitian}
     bg = BipartiteGraph(A; symmetric_pattern)
     vertices_in_order = vertices(bg, Val(2), algo.order)
-    color = partial_distance2_coloring(bg, Val(2), vertices_in_order)
+    color = partial_distance2_coloring(bg, Val(2), vertices_in_order; forced_colors)
     if speed_setting isa WithResult
         return ColumnColoringResult(A, bg, color)
     else
@@ -244,12 +245,13 @@ function _coloring(
     ::ColoringProblem{:nonsymmetric,:row},
     algo::GreedyColoringAlgorithm,
     decompression_eltype::Type,
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 )
     symmetric_pattern = symmetric_pattern || A isa Union{Symmetric,Hermitian}
     bg = BipartiteGraph(A; symmetric_pattern)
     vertices_in_order = vertices(bg, Val(1), algo.order)
-    color = partial_distance2_coloring(bg, Val(1), vertices_in_order)
+    color = partial_distance2_coloring(bg, Val(1), vertices_in_order; forced_colors)
     if speed_setting isa WithResult
         return RowColoringResult(A, bg, color)
     else
@@ -263,11 +265,14 @@ function _coloring(
     ::ColoringProblem{:symmetric,:column},
     algo::GreedyColoringAlgorithm{:direct},
     decompression_eltype::Type,
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 )
     ag = AdjacencyGraph(A; has_diagonal=true)
     vertices_in_order = vertices(ag, algo.order)
-    color, star_set = star_coloring(ag, vertices_in_order, algo.postprocessing)
+    color, star_set = star_coloring(
+        ag, vertices_in_order, algo.postprocessing; forced_colors
+    )
     if speed_setting isa WithResult
         return StarSetColoringResult(A, ag, color, star_set)
     else
@@ -281,11 +286,14 @@ function _coloring(
     ::ColoringProblem{:symmetric,:column},
     algo::GreedyColoringAlgorithm{:substitution},
     decompression_eltype::Type{R},
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 ) where {R}
     ag = AdjacencyGraph(A; has_diagonal=true)
     vertices_in_order = vertices(ag, algo.order)
-    color, tree_set = acyclic_coloring(ag, vertices_in_order, algo.postprocessing)
+    color, tree_set = acyclic_coloring(
+        ag, vertices_in_order, algo.postprocessing; forced_colors
+    )
     if speed_setting isa WithResult
         return TreeSetColoringResult(A, ag, color, tree_set, R)
     else
@@ -299,12 +307,15 @@ function _coloring(
     ::ColoringProblem{:nonsymmetric,:bidirectional},
     algo::GreedyColoringAlgorithm{:direct},
     decompression_eltype::Type{R},
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 ) where {R}
     A_and_Aᵀ, edge_to_index = bidirectional_pattern(A; symmetric_pattern)
     ag = AdjacencyGraph(A_and_Aᵀ, edge_to_index; has_diagonal=false)
     vertices_in_order = vertices(ag, algo.order)
-    color, star_set = star_coloring(ag, vertices_in_order, algo.postprocessing)
+    color, star_set = star_coloring(
+        ag, vertices_in_order, algo.postprocessing; forced_colors
+    )
     if speed_setting isa WithResult
         symmetric_result = StarSetColoringResult(A_and_Aᵀ, ag, color, star_set)
         return BicoloringResult(A, ag, symmetric_result, R)
@@ -322,12 +333,15 @@ function _coloring(
     ::ColoringProblem{:nonsymmetric,:bidirectional},
     algo::GreedyColoringAlgorithm{:substitution},
     decompression_eltype::Type{R},
-    symmetric_pattern::Bool,
+    symmetric_pattern::Bool;
+    forced_colors::Union{AbstractVector{<:Integer},Nothing}=nothing,
 ) where {R}
     A_and_Aᵀ, edge_to_index = bidirectional_pattern(A; symmetric_pattern)
     ag = AdjacencyGraph(A_and_Aᵀ, edge_to_index; has_diagonal=false)
     vertices_in_order = vertices(ag, algo.order)
-    color, tree_set = acyclic_coloring(ag, vertices_in_order, algo.postprocessing)
+    color, tree_set = acyclic_coloring(
+        ag, vertices_in_order, algo.postprocessing; forced_colors
+    )
     if speed_setting isa WithResult
         symmetric_result = TreeSetColoringResult(A_and_Aᵀ, ag, color, tree_set, R)
         return BicoloringResult(A, ag, symmetric_result, R)

--- a/test/adtypes.jl
+++ b/test/adtypes.jl
@@ -1,26 +1,49 @@
 using ADTypes: ADTypes
 using SparseArrays
+using LinearAlgebra
 using SparseMatrixColorings
 using Test
 
-@testset "Column coloring" begin
-    problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
-    algo = ADTypes.NoColoringAlgorithm()
-    A = sprand(10, 20, 0.1)
-    result = coloring(A, problem, algo)
-    B = compress(A, result)
-    @test size(B) == size(A)
-    @test column_colors(result) == ADTypes.column_coloring(A, algo)
-    @test decompress(B, result) == A
-end
+@testset "NoColoringAlgorithm" begin
+    @testset "Column coloring" begin
+        problem = ColoringProblem(; structure=:nonsymmetric, partition=:column)
+        algo = ADTypes.NoColoringAlgorithm()
+        A = sprand(10, 20, 0.3)
+        result = coloring(A, problem, algo)
+        B = compress(A, result)
+        @test size(B) == size(A)
+        @test column_colors(result) == ADTypes.column_coloring(A, algo)
+        @test decompress(B, result) == A
+    end
 
-@testset "Row coloring" begin
-    problem = ColoringProblem(; structure=:nonsymmetric, partition=:row)
-    algo = ADTypes.NoColoringAlgorithm()
-    A = sprand(10, 20, 0.1)
-    result = coloring(A, problem, algo)
-    B = compress(A, result)
-    @test size(B) == size(A)
-    @test row_colors(result) == ADTypes.row_coloring(A, algo)
-    @test decompress(B, result) == A
+    @testset "Row coloring" begin
+        problem = ColoringProblem(; structure=:nonsymmetric, partition=:row)
+        algo = ADTypes.NoColoringAlgorithm()
+        A = sprand(10, 20, 0.3)
+        result = coloring(A, problem, algo)
+        B = compress(A, result)
+        @test size(B) == size(A)
+        @test row_colors(result) == ADTypes.row_coloring(A, algo)
+        @test decompress(B, result) == A
+    end
+
+    @testset "Symmetric coloring" begin
+        problem = ColoringProblem(; structure=:symmetric, partition=:column)
+        algo = ADTypes.NoColoringAlgorithm()
+        A = Symmetric(sprand(20, 20, 0.3))
+        result = coloring(A, problem, algo)
+        B = compress(A, result)
+        @test size(B) == size(A)
+        @test column_colors(result) == ADTypes.column_coloring(A, algo)
+        @test decompress(B, result) == A
+    end
+
+    @testset "Bicoloring" begin
+        problem = ColoringProblem(; structure=:nonsymmetric, partition=:bidirectional)
+        algo = ADTypes.NoColoringAlgorithm()
+        A = sprand(10, 20, 0.3)
+        result = coloring(A, problem, algo)
+        Br, Bc = compress(A, result)
+        @test decompress(Br, Bc, result) == A
+    end
 end


### PR DESCRIPTION
Fixes #67

**Context**

At the moment, DI can only use algorithms from SMC, but people might want to code other coloring algorithms following the [ADTypes interface](https://docs.sciml.ai/ADTypes/stable/#Coloring-algorithm), for instance our friend @SouthEndMusic who was interested in provably optimal colorings. During decompression, we will still need SMC result types, but those are deeply tied to the coloring algorithm itself (for star and acyclic colorings + their bidirectional counterparts). How do we create SMC results from a generic algorithm which outputs only a vector of colors?

**Idea**

Pretend we run the greedy algorithm, but force the color choices and only piggyback the rest of the procedure for constructing data structures like the `StarSet` and `TreeSet`. This enables maximum code reuse.

**Todo**

- [ ] Test on a non-trivial coloring algorithm (not just `ADTypes.NoColoringAlgorithm`)
- [ ] Solve https://github.com/SciML/ADTypes.jl/issues/69 and then integrate that
- [ ] Figure out whether we can accept zero (unused) colors in the output of `ADTypes.symmetric_coloring`