### PR TITLE
chore: fix typo in package UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
-Colors = "5ae59095-9ag9b-59fe-a467-6f913c188581"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 
 [extensions]
 SparseMatrixColoringsCUDAExt = "CUDA"


### PR DESCRIPTION
Reverts typo introduced in #268 