### PR TITLE
Test CI on GPU

### DIFF
--- a/src/SparseMatrixColorings.jl
+++ b/src/SparseMatrixColorings.jl
@@ -73,4 +73,5 @@ export column_groups, row_groups
 export sparsity_pattern
 export compress, decompress, decompress!, decompress_single_color!
 
+
 end


### PR DESCRIPTION
It seems that we have some scalar indexing now.

Update: It seems that the culprit is CUDA 5.9.6.